### PR TITLE
Refine client schedule view layout

### DIFF
--- a/event-planer-main/assets/new-ui.js
+++ b/event-planer-main/assets/new-ui.js
@@ -869,22 +869,29 @@
       state.project.view.selectedTaskId=selectedId;
     }
     const selectedTask = selectedId ? getTaskById(selectedId) : null;
+    const isCatalogMount = catalogTarget && root === catalogTarget;
     root.innerHTML="";
     const screen=el("div","client-screen");
     const timeline=el("div","client-timeline");
     renderTimeline(timeline, selectedId);
     screen.appendChild(timeline);
-
-    const layout=el("div","client-layout");
-    const catalog=el("div","task-catalog");
-    const card=el("div","task-card");
-    layout.appendChild(catalog);
-    layout.appendChild(card);
-    screen.appendChild(layout);
     root.appendChild(screen);
 
-    renderCatalog(catalog, visible.length?visible:tasks, selectedId);
-    renderTaskCard(card, selectedTask);
+    if(isCatalogMount){
+      const layout=el("div","client-layout");
+      const catalog=el("div","task-catalog");
+      const card=el("div","task-card");
+      layout.appendChild(catalog);
+      layout.appendChild(card);
+      screen.appendChild(layout);
+
+      renderCatalog(catalog, visible.length?visible:tasks, selectedId);
+      renderTaskCard(card, selectedTask);
+    }else{
+      const info=el("div","client-info");
+      info.appendChild(el("p",null,"Gestiona los detalles completos de las tareas desde el Catálogo de Tareas."));
+      screen.appendChild(info);
+    }
   };
 
   window.renderClient = ()=>{
@@ -1088,14 +1095,24 @@ const a=document.createElement("a");
   document.addEventListener("DOMContentLoaded", ()=>{
     ensureViewDefaults();
     syncStaffSessions();
+    const showClientView = ()=>{
+      const cliente=document.getElementById("clienteView");
+      const catalog=document.getElementById("catalogView");
+      const result=document.getElementById("resultView");
+      if(cliente) cliente.style.display="";
+      if(catalog) catalog.style.display="none";
+      if(result) result.style.display="none";
+    };
+
     const tabs=document.getElementById("personTabs");
     if(tabs){
       tabs.innerHTML="";
       const btn=el("button","tab active","Horario del cliente");
-      btn.onclick=()=>{ state.project.view.lastTab="CLIENTE"; renderClient(); };
+      btn.onclick=()=>{ showClientView(); state.project.view.lastTab="CLIENTE"; renderClient(); };
       tabs.appendChild(btn);
     }
     ensureDefaultClientTarget();
+    showClientView();
     renderClient();
   });
 })();


### PR DESCRIPTION
## Summary
- limit the client schedule view to the timeline and direct users to the task catalog for detailed editing
- keep the full task catalog layout available only inside the catalog view
- ensure the "Horario del cliente" tab explicitly shows the client schedule panel when clicked

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5ab405ca4832a826fabb1d854861e