### PR TITLE
Insert new client schedule tasks after selected task

### DIFF
--- a/event-planer-main/assets/new-ui.js
+++ b/event-planer-main/assets/new-ui.js
@@ -204,7 +204,23 @@
       actionType: ACTION_TYPE_NORMAL
     };
     ensureDuration(task);
-    list.push(task);
+    let insertIndex = list.length;
+    const selectedId = state?.project?.view?.selectedTaskId || null;
+    if(selectedId){
+      const selectedIndex = list.findIndex(t=>t.id===selectedId);
+      if(selectedIndex !== -1){
+        const selectedTask = list[selectedIndex];
+        const sameParent = (selectedTask.structureParentId || null) === (parentId || null);
+        if(parentId){
+          if(sameParent && selectedTask.structureRelation === task.structureRelation){
+            insertIndex = selectedIndex + 1;
+          }
+        }else if(sameParent){
+          insertIndex = selectedIndex + 1;
+        }
+      }
+    }
+    list.splice(insertIndex, 0, task);
     touchTask(task);
     state.project.view.selectedTaskId = task.id;
     return task;


### PR DESCRIPTION
## Summary
- insert new client schedule tasks immediately after the currently selected task within the client session list
- keep hierarchy integrity by only reordering when the selected task matches the new task's parent and relation

## Testing
- no automated tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5b3c8d2a4832ab20e7e29ef3d5d2d