### PR TITLE
Refine task catalog to read-only schedule view

### DIFF
--- a/event-planer-main/assets/app.css
+++ b/event-planer-main/assets/app.css
@@ -117,6 +117,8 @@ table.matlist td.act{width:120px}
 .timeline-head h3{margin:0;font-size:1rem;letter-spacing:.08em;text-transform:uppercase;color:#94a3b8}
 .timeline-track{display:flex;flex-wrap:wrap;gap:.6rem}
 .timeline-card{display:flex;flex-direction:column;gap:.2rem;align-items:flex-start;background:#0b1220;border:1px solid #1f2937;border-radius:.7rem;padding:.6rem .75rem;color:#e5e7eb;min-width:160px;cursor:pointer}
+.timeline-card.readonly{cursor:default}
+.timeline-card.readonly:hover{border-color:#1f2937}
 .timeline-card .time{font-variant-numeric:tabular-nums;font-weight:600}
 .timeline-card .title{font-size:1rem;font-weight:600}
 .timeline-card .mini{color:#94a3b8}
@@ -148,10 +150,8 @@ table.matlist td.act{width:120px}
 .duration-label{font-weight:600;font-size:.85rem}
 .client-layout{display:grid;grid-template-columns:minmax(280px,340px) 1fr;gap:1.4rem}
 .task-catalog{display:flex;flex-direction:column;gap:1rem}
-.catalog-toolbar{display:flex}
-.catalog-section{background:#0f172a;border:1px solid #1f2937;border-radius:.75rem;padding:.8rem;display:flex;flex-direction:column;gap:.55rem}
-.catalog-title{font-size:.9rem;font-weight:600;letter-spacing:.05em;text-transform:uppercase;color:#94a3b8}
-.catalog-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(210px,1fr));gap:.6rem}
+.catalog-list{display:flex;flex-direction:column;gap:.6rem}
+.catalog-entry{width:100%}
 .catalog-item{display:flex;flex-direction:column;gap:.35rem;align-items:flex-start;background:#0b1220;border:1px solid #1f2937;border-radius:.75rem;padding:.7rem .8rem;color:#e5e7eb;text-align:left;cursor:pointer}
 .catalog-item .mini{margin-top:.1rem}
 .catalog-item.active{border-color:#3b82f6;box-shadow:0 0 0 1px #3b82f6}
@@ -198,16 +198,22 @@ table.matlist td.act{width:120px}
 .status-chip{padding:.25rem .6rem;border-radius:.65rem;font-size:.75rem;text-transform:uppercase;letter-spacing:.05em}
 .status-chip.ok{background:#166534;color:#dcfce7}
 .status-chip.warn{background:#7f1d1d;color:#fee2e2}
+.task-details{display:flex;flex-direction:column;gap:.65rem}
+.detail-row{display:flex;justify-content:space-between;gap:.8rem;align-items:flex-start}
+.detail-label{font-size:.8rem;font-weight:600;letter-spacing:.05em;text-transform:uppercase;color:#94a3b8}
+.detail-value{font-variant-numeric:tabular-nums;color:#e5e7eb}
+.detail-notes{display:flex;flex-direction:column;gap:.35rem}
+.detail-text{margin:0;color:#cbd5f5;line-height:1.4}
 .task-breadcrumb{display:flex;flex-wrap:wrap;gap:.35rem;align-items:center;font-size:.85rem}
 .crumb{background:#111827;border:1px solid #1f2937;color:#e5e7eb;padding:.25rem .6rem;border-radius:.55rem;cursor:pointer}
 .crumb:disabled{opacity:.6;cursor:default}
 .crumb-sep{opacity:.6}
-.task-form{display:flex;flex-direction:column;gap:.75rem}
-.field-row{display:flex;flex-direction:column;gap:.35rem}
-.field-row label{font-weight:600;font-size:.85rem;color:#cbd5f5}
-.field-row .input, .field-row select, .field-row textarea{width:100%}
 .materials-list{display:flex;flex-direction:column;gap:.45rem}
+.materials-list.readonly{gap:.35rem}
 .material-row{display:flex;gap:.45rem;align-items:center}
+.material-row.readonly{justify-content:space-between;gap:.8rem}
+.material-name{font-weight:600;color:#e5e7eb}
+.material-qty{font-variant-numeric:tabular-nums;color:#94a3b8}
 .staff-picker{display:flex;flex-wrap:wrap;gap:.45rem}
 .staff-toggle{background:#111827;border:1px solid #1f2937;color:#e5e7eb;border-radius:.6rem;padding:.35rem .65rem;cursor:pointer}
 .staff-toggle.active{background:#047857;border-color:#059669;color:#fff}

--- a/event-planer-main/assets/new-ui.js
+++ b/event-planer-main/assets/new-ui.js
@@ -612,58 +612,16 @@
     container.innerHTML="";
     const header=el("div","timeline-head");
     header.appendChild(el("h3",null,"Horario fijo del cliente"));
-    const selectedTask = selectedId ? getTaskById(selectedId) : null;
-    const addBtn=el("button","btn small","Crear tarea");
-    const handleCreate=()=>{
-      const task=createTimelineMilestone();
-      if(task){
-        selectTask(task.id);
-        renderClient();
-      }
-    };
-    addBtn.onclick=handleCreate;
-    header.appendChild(addBtn);
-    const deleteBtn=el("button","btn small danger","Eliminar tarea");
-    const handleDelete=()=>{
-      if(!selectedTask || selectedTask.structureRelation!=="milestone") return;
-      if(!confirm("¿Eliminar esta tarea y sus dependientes?")) return;
-      const parentId=selectedTask.structureParentId;
-      const deletedId=selectedTask.id;
-      deleteTask(deletedId);
-      let nextSelection=null;
-      if(parentId){
-        nextSelection=parentId;
-      }else{
-        const remaining=getOrderedMilestones();
-        nextSelection=remaining[0]?.id || null;
-      }
-      selectTask(nextSelection);
-      if(state.project.view.timelineEditorId===deletedId){
-        const nextTask = nextSelection ? getTaskById(nextSelection) : null;
-        state.project.view.timelineEditorId = nextTask && nextTask.structureRelation==="milestone" ? nextTask.id : null;
-      }
-      renderClient();
-    };
-    deleteBtn.onclick=handleDelete;
-    deleteBtn.disabled = !(selectedTask && selectedTask.structureRelation==="milestone");
-    header.appendChild(deleteBtn);
     container.appendChild(header);
 
     const milestones=getOrderedMilestones();
-    if(!milestones.length){
-      addBtn.disabled = !hasInitialTime() || !hasInitialLocation();
-    }else{
-      addBtn.disabled = false;
-    }
-
     const list=el("div","timeline-track");
     if(!milestones.length){
       list.appendChild(el("div","timeline-empty","Todavía no hay tareas en el horario."));
     }else{
-      const editorId = resolveTimelineEditorId(milestones, selectedId);
       milestones.forEach(task=>{
-        const card=el("button","timeline-card");
-        if(task.id===editorId) card.classList.add("active");
+        const card=el("div","timeline-card readonly");
+        if(task.id===selectedId) card.classList.add("active");
         const hasRange=(task.startMin!=null && task.endMin!=null);
         const time=hasRange ? `${toHHMM(task.startMin)} – ${toHHMM(task.endMin)}` : (task.startMin!=null ? toHHMM(task.startMin) : "Sin hora");
         card.appendChild(el("div","time",time));
@@ -678,104 +636,63 @@
           subtitle=locationNameById(task.locationId) || "Sin localización";
         }
         card.appendChild(el("div","mini",subtitle));
-        card.onclick=()=>{
-          selectTask(task.id);
-          state.project.view.timelineEditorId = task.id;
-          renderClient();
-        };
         list.appendChild(card);
       });
     }
     container.appendChild(list);
-
-    if(!milestones.length){
-      state.project.view.timelineEditorId = null;
-      container.appendChild(buildInitialConfig());
-    }else{
-      const editorId = resolveTimelineEditorId(milestones, selectedId);
-      const editorTask = editorId ? milestones.find(t=>t.id===editorId) : null;
-      if(editorTask){
-        container.appendChild(buildTimelineEditor(editorTask));
-      }
-    }
   };
 
   const renderCatalog = (container, tasks, selectedId)=>{
     container.innerHTML="";
-    const toolbar=el("div","catalog-toolbar");
-    const addBtn=el("button","btn primary full","+ Nuevo hito" );
-    addBtn.onclick=()=>{ createTask({relation:"milestone"}); renderClient(); };
-    toolbar.appendChild(addBtn);
-    container.appendChild(toolbar);
+    const listWrap=el("div","catalog-list");
+    const list=sortedTasks(tasks);
+    if(!list.length){
+      listWrap.appendChild(el("div","mini muted","Sin tareas"));
+    }else{
+      list.forEach(task=>{
+        const item=el("button","catalog-item catalog-entry","");
+        if(task.id===selectedId) item.classList.add("active");
+        item.onclick=()=>{ selectTask(task.id); renderClient(); };
 
-    const sections=[
-      { key:"pending", title:"Acciones con datos pendientes", filter:(t)=>!isTaskComplete(t) },
-      { key:"complete", title:"Acciones completas", filter:(t)=>isTaskComplete(t) }
-    ];
+        const title=el("div","catalog-name",labelForTask(task));
+        item.appendChild(title);
+        const relationLabel=RELATION_LABEL[task.structureRelation] || "Tarea";
+        item.appendChild(el("span","relation-tag",relationLabel));
+        const meta=el("div","catalog-meta");
+        const time=task.startMin!=null ? toHHMM(task.startMin) : "Sin hora";
+        meta.appendChild(el("span","catalog-time",time));
+        const duration=task.durationMin!=null ? `${task.durationMin} min` : "Sin duración";
+        meta.appendChild(el("span","catalog-duration",duration));
+        item.appendChild(meta);
 
-    sections.forEach(section=>{
-      const sec=el("div","catalog-section");
-      sec.appendChild(el("div","catalog-title",section.title));
-      const list=sortedTasks(tasks.filter(section.filter));
-      if(!list.length){
-        sec.appendChild(el("div","mini muted","Sin tareas"));
-      }else{
-        const grid=el("div","catalog-grid");
-        list.forEach(task=>{
-          const item=el("button","catalog-item","");
-          if(task.id===selectedId) item.classList.add("active");
-          item.onclick=()=>{ selectTask(task.id); renderClient(); };
-
-          const title=el("div","catalog-name",labelForTask(task));
-          item.appendChild(title);
-          const relationLabel=RELATION_LABEL[task.structureRelation] || "Tarea";
-          item.appendChild(el("span","relation-tag",relationLabel));
-          const meta=el("div","catalog-meta");
-          const time=task.startMin!=null ? toHHMM(task.startMin) : "Sin hora";
-          meta.appendChild(el("span","catalog-time",time));
-          const duration=task.durationMin!=null ? `${task.durationMin} min` : "Sin duración";
-          meta.appendChild(el("span","catalog-duration",duration));
-          item.appendChild(meta);
-
-          const path=getBreadcrumb(task);
-          if(path.length>1){
-            const trail=path.slice(0,-1).map(node=>labelForTask(node)).join(" · ");
-            item.appendChild(el("div","mini muted",trail));
-          }
-          grid.appendChild(item);
-        });
-        sec.appendChild(grid);
-      }
-      container.appendChild(sec);
-    });
+        const path=getBreadcrumb(task);
+        if(path.length>1){
+          const trail=path.slice(0,-1).map(node=>labelForTask(node)).join(" · ");
+          item.appendChild(el("div","mini muted",trail));
+        }
+        listWrap.appendChild(item);
+      });
+    }
+    container.appendChild(listWrap);
   };
+
+  const materialTypeNameById = (id)=> (state.materialTypes||[]).find(mt=>mt.id===id)?.nombre || "Material";
 
   const renderMaterials = (task)=>{
     const wrap=el("div","materials-section");
     wrap.appendChild(el("h4",null,"Materiales"));
-    const table=el("div","materials-list");
+    const table=el("div","materials-list readonly");
     if(!task.materiales.length){
       table.appendChild(el("div","mini muted","Sin materiales"));
     }
-    task.materiales.forEach((mat,idx)=>{
-      const row=el("div","material-row");
-      const sel=el("select","input");
-      const opt0=el("option",null,"- seleccionar -"); opt0.value=""; sel.appendChild(opt0);
-      (state.materialTypes||[]).forEach(mt=>{
-        const opt=el("option",null,mt.nombre||"Material"); opt.value=mt.id; if(mt.id===mat.materialTypeId) opt.selected=true; sel.appendChild(opt);
-      });
-      sel.onchange=()=>{ task.materiales[idx].materialTypeId = sel.value||null; touchTask(task); renderClient(); };
-      const qty=el("input","input"); qty.type="number"; qty.min="0"; qty.step="1"; qty.value=String(mat.cantidad||0);
-      qty.onchange=()=>{ task.materiales[idx].cantidad = Number(qty.value)||0; touchTask(task); };
-      const del=el("button","btn small", "Quitar");
-      del.onclick=()=>{ task.materiales.splice(idx,1); touchTask(task); renderClient(); };
-      row.appendChild(sel); row.appendChild(qty); row.appendChild(del);
+    task.materiales.forEach(mat=>{
+      const row=el("div","material-row readonly");
+      const name=materialTypeNameById(mat.materialTypeId);
+      row.appendChild(el("div","material-name",name));
+      row.appendChild(el("div","material-qty",`${Number(mat.cantidad||0)} uds`));
       table.appendChild(row);
     });
-    const add=el("button","btn small", "Añadir material");
-    add.onclick=()=>{ task.materiales.push({materialTypeId:null,cantidad:0}); touchTask(task); renderClient(); };
     wrap.appendChild(table);
-    wrap.appendChild(add);
     return wrap;
   };
 
@@ -815,9 +732,6 @@
     area.dataset.relation=relation;
     const head=el("div","nexo-head");
     head.appendChild(el("h4",null,label));
-    const add=el("button","btn small","+ Añadir");
-    add.onclick=()=>{ createTask({ parentId:task.id, relation }); renderClient(); };
-    head.appendChild(add);
     area.appendChild(head);
     const children=getTaskChildren(task.id).filter(ch=>ch.structureRelation===relation);
     if(!children.length){
@@ -883,157 +797,49 @@
     });
     center.appendChild(breadcrumb);
 
-    const form=el("div","task-form");
-    const durationRow=el("div","field-row");
-    durationRow.appendChild(el("label",null,"Duración (min)"));
-    const durInput=el("input","input"); durInput.type="number"; durInput.min="5"; durInput.step="5"; durInput.value=String(task.durationMin||60);
-    durInput.onchange=()=>{
-      const v=Math.max(5, Math.round(Number(durInput.value)||60));
-      task.durationMin=v;
-      if(task.startMin!=null){ task.endMin = task.startMin + v; }
-      touchTask(task);
-      renderClient();
+    const details=el("div","task-details");
+    const addDetail=(label,value)=>{
+      const row=el("div","detail-row");
+      row.appendChild(el("span","detail-label",label));
+      row.appendChild(el("span","detail-value",value||"—"));
+      details.appendChild(row);
     };
-    durationRow.appendChild(durInput);
-    form.appendChild(durationRow);
-
-    const nameRow=el("div","field-row");
-    nameRow.appendChild(el("label",null,"Nombre"));
-    const nameInput=el("input","input"); nameInput.type="text"; nameInput.value=task.actionName||"";
-    nameInput.oninput=()=>{ task.actionName=nameInput.value; title.textContent=labelForTask(task); };
-    nameInput.onblur=()=>{ touchTask(task); renderClient(); };
-    nameRow.appendChild(nameInput);
-    form.appendChild(nameRow);
 
     if(task.structureRelation==="milestone"){
-      const timeRow=el("div","field-row");
-      timeRow.appendChild(el("label",null,"Hora"));
-      const timeInput=el("input","input"); timeInput.type="time"; timeInput.value=formatTimeValue(task.startMin);
-      timeInput.onchange=()=>{
-        const v=parseTimeInput(timeInput.value);
-        task.startMin=v;
-        if(v==null){ task.endMin=null; }
-        else task.endMin=v + Math.max(5, Number(task.durationMin)||60);
-        touchTask(task);
-        renderClient();
-      };
-      timeRow.appendChild(timeInput);
-      form.appendChild(timeRow);
+      const hasRange=task.startMin!=null && task.endMin!=null;
+      const horario=hasRange ? `${toHHMM(task.startMin)} – ${toHHMM(task.endMin)}` : (task.startMin!=null ? toHHMM(task.startMin) : "Sin hora");
+      addDetail("Horario",horario);
     }else{
-      const limitRow=el("div","field-row");
       if(task.structureRelation==="post"){
-        limitRow.appendChild(el("label",null,"Límite tarde"));
-        const limitInput=el("input","input"); limitInput.type="time"; limitInput.value=formatTimeValue(task.limitLateMin);
-        limitInput.onchange=()=>{
-          task.limitLateMin=parseTimeInput(limitInput.value);
-          touchTask(task);
-          renderClient();
-        };
-        limitRow.appendChild(limitInput);
+        addDetail("Límite tarde", task.limitLateMin!=null ? toHHMM(task.limitLateMin) : "Sin límite");
       }else{
-        limitRow.appendChild(el("label",null,"Límite temprano"));
-        const limitInput=el("input","input"); limitInput.type="time"; limitInput.value=formatTimeValue(task.limitEarlyMin);
-        limitInput.onchange=()=>{
-          task.limitEarlyMin=parseTimeInput(limitInput.value);
-          touchTask(task);
-          renderClient();
-        };
-        limitRow.appendChild(limitInput);
+        addDetail("Límite temprano", task.limitEarlyMin!=null ? toHHMM(task.limitEarlyMin) : "Sin límite");
       }
-      form.appendChild(limitRow);
-
-      const startRow=el("div","field-row");
-      startRow.appendChild(el("label",null,"Hora exacta (opcional)"));
-      const startInput=el("input","input"); startInput.type="time"; startInput.value=formatTimeValue(task.startMin);
-      startInput.onchange=()=>{
-        const v=parseTimeInput(startInput.value);
-        task.startMin=v;
-        if(v==null){ task.endMin=null; }
-        else task.endMin=v + Math.max(5, Number(task.durationMin)||60);
-        touchTask(task);
-        renderClient();
-      };
-      startRow.appendChild(startInput);
-      form.appendChild(startRow);
+      addDetail("Hora exacta", task.startMin!=null ? toHHMM(task.startMin) : "Sin hora");
     }
+    addDetail("Duración", task.durationMin!=null ? `${task.durationMin} min` : "Sin duración");
 
-    const locRow=el("div","field-row");
-    locRow.appendChild(el("label",null, task.actionType===ACTION_TYPE_TRANSPORT?"Destino":"Localización"));
-    const locSelect=el("select","input");
-    const optEmpty=el("option",null,"- seleccionar -"); optEmpty.value=""; locSelect.appendChild(optEmpty);
-    (state.locations||[]).forEach(loc=>{
-      const opt=el("option",null,loc.nombre||"Localización"); opt.value=loc.id; if(loc.id===task.locationId) opt.selected=true; locSelect.appendChild(opt);
-    });
-    if(task.actionType===ACTION_TYPE_TRANSPORT && task.locationApplies!==true){
-      task.locationApplies = true;
-    }
-    const locationDisabled = task.actionType!==ACTION_TYPE_TRANSPORT && task.locationApplies!==true;
-    locSelect.disabled = locationDisabled;
-    locSelect.onchange=()=>{ task.locationId = locSelect.value||null; touchTask(task); renderClient(); };
-    locRow.appendChild(locSelect);
-    if(task.actionType!==ACTION_TYPE_TRANSPORT){
-      const locToggle=el("label","check");
-      const chk=el("input"); chk.type="checkbox"; chk.checked=!task.locationApplies;
-      chk.onchange=()=>{ task.locationApplies = !chk.checked; if(!task.locationApplies) task.locationId=null; touchTask(task); renderClient(); };
-      locToggle.appendChild(chk);
-      locToggle.appendChild(el("span",null,"Sin localización"));
-      locRow.appendChild(locToggle);
-    }else{
+    if(task.actionType===ACTION_TYPE_TRANSPORT){
       const flow=transportFlowForTask(task);
       const originName=locationNameById(flow.origin) || "Sin origen";
       const destName=locationNameById(flow.destination) || "Sin destino";
-      locRow.appendChild(el("div","mini",`Origen → ${originName} · Destino → ${destName}`));
-    }
-    form.appendChild(locRow);
-
-    if(task.actionType===ACTION_TYPE_TRANSPORT){
-      if(!task.vehicleId){
-        const def=defaultVehicleId();
-        if(def){
-          task.vehicleId=def;
-          touchTask(task);
-        }
-      }
-      const vehicleRow=el("div","field-row");
-      vehicleRow.appendChild(el("label",null,"Vehículo"));
-      const vehicleSelect=el("select","input");
-      const vehEmpty=el("option",null,"- seleccionar -"); vehEmpty.value=""; vehicleSelect.appendChild(vehEmpty);
-      (state.vehicles||[]).forEach(veh=>{
-        const opt=el("option",null,veh.nombre||"Vehículo"); opt.value=veh.id; if(veh.id===task.vehicleId) opt.selected=true; vehicleSelect.appendChild(opt);
-      });
-      vehicleSelect.onchange=()=>{ task.vehicleId = vehicleSelect.value||null; touchTask(task); };
-      vehicleRow.appendChild(vehicleSelect);
-      form.appendChild(vehicleRow);
+      addDetail("Origen", originName);
+      addDetail("Destino", destName);
+    }else if(task.locationApplies!==false){
+      addDetail("Localización", locationNameById(task.locationId) || "Sin localización");
+    }else{
+      addDetail("Localización", "Sin localización");
     }
 
-    const notesRow=el("div","field-row");
-    notesRow.appendChild(el("label",null,"Notas"));
-    const notes=el("textarea","input"); notes.rows=4; notes.value=task.comentario||"";
-    notes.oninput=()=>{ task.comentario=notes.value; };
-    notes.onblur=()=>{ touchTask(task); };
-    notesRow.appendChild(notes);
-    form.appendChild(notesRow);
+    if((task.comentario||"").trim()){
+      const notes=el("div","detail-notes");
+      notes.appendChild(el("span","detail-label","Notas"));
+      notes.appendChild(el("p","detail-text",task.comentario));
+      details.appendChild(notes);
+    }
 
-    center.appendChild(form);
+    center.appendChild(details);
     center.appendChild(renderStaffPicker(task));
-
-    const danger=el("button","btn danger", "Eliminar tarea");
-    danger.onclick=()=>{
-      if(confirm("¿Eliminar esta tarea y sus dependientes?")){
-        const parentId=task.structureParentId;
-        deleteTask(task.id);
-        if(parentId){
-          selectTask(parentId);
-        }else{
-          const next=getTaskList()[0];
-          selectTask(next?next.id:null);
-        }
-        renderClient();
-      }
-    };
-    const actions=el("div","task-actions");
-    actions.appendChild(danger);
-    center.appendChild(actions);
 
     grid.appendChild(renderNexoArea(task,"pre","Pretareas","top"));
     grid.appendChild(renderNexoArea(task,"parallel","Concurrencia","left"));


### PR DESCRIPTION
## Summary
- remove creation and deletion controls from the fixed client schedule so it becomes a read-only timeline
- simplify the catalog layout into a single list of client tasks without pending/completed groupings
- present task details in a read-only inspector with staff assignment as the only editable field and materials shown without editors

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5c27a4cb0832a9b44f5bde8303431