### PR TITLE
Simplify task catalog to read-only layout

### DIFF
--- a/event-planer-main/assets/app.css
+++ b/event-planer-main/assets/app.css
@@ -160,6 +160,8 @@ table.matlist td.act{width:120px}
 .catalog-meta{display:flex;gap:.45rem;font-size:.8rem;color:#94a3b8}
 .catalog-time{font-variant-numeric:tabular-nums}
 .catalog-duration{font-style:italic}
+.catalog-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:.8rem}
+.catalog-header h3{margin:0;font-size:1rem;letter-spacing:.08em;text-transform:uppercase;color:#94a3b8}
 .relation-tag{margin-top:.1rem;font-size:.7rem;text-transform:uppercase;letter-spacing:.08em;color:#cbd5f5}
 .task-card{display:flex;flex-direction:column;gap:1.2rem;background:#0b1220;border:1px solid #1f2937;border-radius:.9rem;padding:1.2rem}
 .catalog-base{margin-top:2rem;display:flex;flex-direction:column;gap:1rem}
@@ -212,10 +214,17 @@ table.matlist td.act{width:120px}
 .staff-toggle{background:#111827;border:1px solid #1f2937;color:#e5e7eb;border-radius:.6rem;padding:.35rem .65rem;cursor:pointer}
 .staff-toggle.active{background:#047857;border-color:#059669;color:#fff}
 .empty-card{padding:2rem;border:1px dashed #1f2937;border-radius:.75rem;text-align:center;color:#94a3b8}
+.detail-list{display:flex;flex-direction:column;gap:.6rem}
+.detail-row{display:flex;flex-direction:column;gap:.25rem}
+.detail-label{font-size:.8rem;letter-spacing:.05em;text-transform:uppercase;color:#94a3b8}
+.detail-value{color:#e5e7eb;font-weight:600}
+.detail-note{font-weight:400;color:#cbd5f5;white-space:pre-wrap}
 .materials-section .mini,.staff-section .mini{color:#94a3b8}
 .check{display:flex;align-items:center;gap:.35rem;font-size:.85rem;color:#cbd5f5}
 .task-actions{margin-top:auto}
 .task-actions .btn{width:100%}
+.timeline-card.readonly{cursor:default}
+.timeline-card.readonly:hover{border-color:#1f2937}
 
 @media (max-width:1100px){
   .client-layout{grid-template-columns:1fr}

--- a/event-planer-main/assets/new-ui.js
+++ b/event-planer-main/assets/new-ui.js
@@ -700,54 +700,86 @@
     }
   };
 
+  const renderFixedTimeline = (container, selectedId)=>{
+    container.innerHTML="";
+    const header=el("div","timeline-head");
+    header.appendChild(el("h3",null,"Horario fijo del cliente"));
+    container.appendChild(header);
+
+    const milestones=getOrderedMilestones();
+    const list=el("div","timeline-track");
+    if(!milestones.length){
+      list.appendChild(el("div","timeline-empty","Todavía no hay tareas en el horario."));
+    }else{
+      milestones.forEach(task=>{
+        const card=el("div","timeline-card readonly");
+        if(task.id===selectedId) card.classList.add("active");
+        const hasRange=(task.startMin!=null && task.endMin!=null);
+        const time=hasRange ? `${toHHMM(task.startMin)} – ${toHHMM(task.endMin)}` : (task.startMin!=null ? toHHMM(task.startMin) : "Sin hora");
+        card.appendChild(el("div","time",time));
+        card.appendChild(el("div","title",labelForTask(task)));
+        let subtitle="";
+        if(task.actionType===ACTION_TYPE_TRANSPORT){
+          const flow=transportFlowForTask(task);
+          const originName=locationNameById(flow.origin) || "Sin origen";
+          const destName=locationNameById(flow.destination) || "Sin destino";
+          subtitle=`${originName} → ${destName}`;
+        }else{
+          subtitle=locationNameById(task.locationId) || "Sin localización";
+        }
+        card.appendChild(el("div","mini",subtitle));
+        list.appendChild(card);
+      });
+    }
+    container.appendChild(list);
+  };
+
   const renderCatalog = (container, tasks, selectedId)=>{
     container.innerHTML="";
-    const toolbar=el("div","catalog-toolbar");
-    const addBtn=el("button","btn primary full","+ Nuevo hito" );
-    addBtn.onclick=()=>{ createTask({relation:"milestone"}); renderClient(); };
-    toolbar.appendChild(addBtn);
-    container.appendChild(toolbar);
+    const header=el("div","catalog-header");
+    header.appendChild(el("h3",null,"Tareas del cliente"));
+    container.appendChild(header);
 
-    const sections=[
-      { key:"pending", title:"Acciones con datos pendientes", filter:(t)=>!isTaskComplete(t) },
-      { key:"complete", title:"Acciones completas", filter:(t)=>isTaskComplete(t) }
-    ];
+    const sorted=sortedTasks(tasks);
+    if(!sorted.length){
+      container.appendChild(el("div","mini muted","Sin tareas"));
+      return;
+    }
 
-    sections.forEach(section=>{
-      const sec=el("div","catalog-section");
-      sec.appendChild(el("div","catalog-title",section.title));
-      const list=sortedTasks(tasks.filter(section.filter));
-      if(!list.length){
-        sec.appendChild(el("div","mini muted","Sin tareas"));
+    const grid=el("div","catalog-grid");
+    sorted.forEach(task=>{
+      const item=el("button","catalog-item","");
+      if(task.id===selectedId) item.classList.add("active");
+      item.onclick=()=>{ selectTask(task.id); renderClient(); };
+
+      const title=el("div","catalog-name",labelForTask(task));
+      item.appendChild(title);
+      const relationLabel=RELATION_LABEL[task.structureRelation] || "Tarea";
+      item.appendChild(el("span","relation-tag",relationLabel));
+      const meta=el("div","catalog-meta");
+      const hasRange=(task.startMin!=null && task.endMin!=null);
+      const time=hasRange ? `${toHHMM(task.startMin)} – ${toHHMM(task.endMin)}` : (task.startMin!=null ? toHHMM(task.startMin) : "Sin hora");
+      meta.appendChild(el("span","catalog-time",time));
+      const duration=task.durationMin!=null ? `${task.durationMin} min` : "Sin duración";
+      meta.appendChild(el("span","catalog-duration",duration));
+      item.appendChild(meta);
+
+      let locationLabel="";
+      if(task.actionType===ACTION_TYPE_TRANSPORT){
+        const flow=transportFlowForTask(task);
+        const originName=locationNameById(flow.origin) || "Sin origen";
+        const destName=locationNameById(flow.destination) || "Sin destino";
+        locationLabel=`${originName} → ${destName}`;
+      }else if(task.locationApplies===false){
+        locationLabel="No aplica";
       }else{
-        const grid=el("div","catalog-grid");
-        list.forEach(task=>{
-          const item=el("button","catalog-item","");
-          if(task.id===selectedId) item.classList.add("active");
-          item.onclick=()=>{ selectTask(task.id); renderClient(); };
-
-          const title=el("div","catalog-name",labelForTask(task));
-          item.appendChild(title);
-          const relationLabel=RELATION_LABEL[task.structureRelation] || "Tarea";
-          item.appendChild(el("span","relation-tag",relationLabel));
-          const meta=el("div","catalog-meta");
-          const time=task.startMin!=null ? toHHMM(task.startMin) : "Sin hora";
-          meta.appendChild(el("span","catalog-time",time));
-          const duration=task.durationMin!=null ? `${task.durationMin} min` : "Sin duración";
-          meta.appendChild(el("span","catalog-duration",duration));
-          item.appendChild(meta);
-
-          const path=getBreadcrumb(task);
-          if(path.length>1){
-            const trail=path.slice(0,-1).map(node=>labelForTask(node)).join(" · ");
-            item.appendChild(el("div","mini muted",trail));
-          }
-          grid.appendChild(item);
-        });
-        sec.appendChild(grid);
+        locationLabel=locationNameById(task.locationId) || "Sin localización";
       }
-      container.appendChild(sec);
+      item.appendChild(el("div","mini",locationLabel));
+
+      grid.appendChild(item);
     });
+    container.appendChild(grid);
   };
 
   const renderMaterials = (task)=>{
@@ -756,26 +788,18 @@
     const table=el("div","materials-list");
     if(!task.materiales.length){
       table.appendChild(el("div","mini muted","Sin materiales"));
-    }
-    task.materiales.forEach((mat,idx)=>{
-      const row=el("div","material-row");
-      const sel=el("select","input");
-      const opt0=el("option",null,"- seleccionar -"); opt0.value=""; sel.appendChild(opt0);
-      (state.materialTypes||[]).forEach(mt=>{
-        const opt=el("option",null,mt.nombre||"Material"); opt.value=mt.id; if(mt.id===mat.materialTypeId) opt.selected=true; sel.appendChild(opt);
+    }else{
+      task.materiales.forEach(mat=>{
+        const row=el("div","material-row");
+        const id=mat.materialTypeId;
+        const name=(state.materialTypes||[]).find(mt=>mt.id===id)?.nombre || "Material";
+        row.appendChild(el("span","material-name",name));
+        const qty=Math.max(0, Math.round(Number(mat.cantidad)||0));
+        row.appendChild(el("span","material-qty",`${qty}`));
+        table.appendChild(row);
       });
-      sel.onchange=()=>{ task.materiales[idx].materialTypeId = sel.value||null; touchTask(task); renderClient(); };
-      const qty=el("input","input"); qty.type="number"; qty.min="0"; qty.step="1"; qty.value=String(mat.cantidad||0);
-      qty.onchange=()=>{ task.materiales[idx].cantidad = Number(qty.value)||0; touchTask(task); };
-      const del=el("button","btn small", "Quitar");
-      del.onclick=()=>{ task.materiales.splice(idx,1); touchTask(task); renderClient(); };
-      row.appendChild(sel); row.appendChild(qty); row.appendChild(del);
-      table.appendChild(row);
-    });
-    const add=el("button","btn small", "Añadir material");
-    add.onclick=()=>{ task.materiales.push({materialTypeId:null,cantidad:0}); touchTask(task); renderClient(); };
+    }
     wrap.appendChild(table);
-    wrap.appendChild(add);
     return wrap;
   };
 
@@ -815,9 +839,6 @@
     area.dataset.relation=relation;
     const head=el("div","nexo-head");
     head.appendChild(el("h4",null,label));
-    const add=el("button","btn small","+ Añadir");
-    add.onclick=()=>{ createTask({ parentId:task.id, relation }); renderClient(); };
-    head.appendChild(add);
     area.appendChild(head);
     const children=getTaskChildren(task.id).filter(ch=>ch.structureRelation===relation);
     if(!children.length){
@@ -849,7 +870,7 @@
   const renderTaskCard = (container, task)=>{
     container.innerHTML="";
     if(!task){
-      container.appendChild(el("div","empty-card","Selecciona una tarea o crea un nuevo hito."));
+      container.appendChild(el("div","empty-card","Selecciona una tarea para ver los detalles."));
       return;
     }
     applyTaskDefaults(task);
@@ -883,157 +904,51 @@
     });
     center.appendChild(breadcrumb);
 
-    const form=el("div","task-form");
-    const durationRow=el("div","field-row");
-    durationRow.appendChild(el("label",null,"Duración (min)"));
-    const durInput=el("input","input"); durInput.type="number"; durInput.min="5"; durInput.step="5"; durInput.value=String(task.durationMin||60);
-    durInput.onchange=()=>{
-      const v=Math.max(5, Math.round(Number(durInput.value)||60));
-      task.durationMin=v;
-      if(task.startMin!=null){ task.endMin = task.startMin + v; }
-      touchTask(task);
-      renderClient();
+    const details=el("div","detail-list");
+    const addDetail=(label,value)=>{
+      const row=el("div","detail-row");
+      row.appendChild(el("span","detail-label",label));
+      row.appendChild(el("span","detail-value",value || "—"));
+      details.appendChild(row);
     };
-    durationRow.appendChild(durInput);
-    form.appendChild(durationRow);
 
-    const nameRow=el("div","field-row");
-    nameRow.appendChild(el("label",null,"Nombre"));
-    const nameInput=el("input","input"); nameInput.type="text"; nameInput.value=task.actionName||"";
-    nameInput.oninput=()=>{ task.actionName=nameInput.value; title.textContent=labelForTask(task); };
-    nameInput.onblur=()=>{ touchTask(task); renderClient(); };
-    nameRow.appendChild(nameInput);
-    form.appendChild(nameRow);
+    const hasRange=(task.startMin!=null && task.endMin!=null);
+    const schedule=hasRange ? `${toHHMM(task.startMin)} – ${toHHMM(task.endMin)}` : (task.startMin!=null ? toHHMM(task.startMin) : relationInfo(task));
+    addDetail("Horario", schedule);
+    const duration=task.durationMin!=null ? `${task.durationMin} min` : "Sin duración";
+    addDetail("Duración", duration);
 
-    if(task.structureRelation==="milestone"){
-      const timeRow=el("div","field-row");
-      timeRow.appendChild(el("label",null,"Hora"));
-      const timeInput=el("input","input"); timeInput.type="time"; timeInput.value=formatTimeValue(task.startMin);
-      timeInput.onchange=()=>{
-        const v=parseTimeInput(timeInput.value);
-        task.startMin=v;
-        if(v==null){ task.endMin=null; }
-        else task.endMin=v + Math.max(5, Number(task.durationMin)||60);
-        touchTask(task);
-        renderClient();
-      };
-      timeRow.appendChild(timeInput);
-      form.appendChild(timeRow);
-    }else{
-      const limitRow=el("div","field-row");
-      if(task.structureRelation==="post"){
-        limitRow.appendChild(el("label",null,"Límite tarde"));
-        const limitInput=el("input","input"); limitInput.type="time"; limitInput.value=formatTimeValue(task.limitLateMin);
-        limitInput.onchange=()=>{
-          task.limitLateMin=parseTimeInput(limitInput.value);
-          touchTask(task);
-          renderClient();
-        };
-        limitRow.appendChild(limitInput);
-      }else{
-        limitRow.appendChild(el("label",null,"Límite temprano"));
-        const limitInput=el("input","input"); limitInput.type="time"; limitInput.value=formatTimeValue(task.limitEarlyMin);
-        limitInput.onchange=()=>{
-          task.limitEarlyMin=parseTimeInput(limitInput.value);
-          touchTask(task);
-          renderClient();
-        };
-        limitRow.appendChild(limitInput);
-      }
-      form.appendChild(limitRow);
-
-      const startRow=el("div","field-row");
-      startRow.appendChild(el("label",null,"Hora exacta (opcional)"));
-      const startInput=el("input","input"); startInput.type="time"; startInput.value=formatTimeValue(task.startMin);
-      startInput.onchange=()=>{
-        const v=parseTimeInput(startInput.value);
-        task.startMin=v;
-        if(v==null){ task.endMin=null; }
-        else task.endMin=v + Math.max(5, Number(task.durationMin)||60);
-        touchTask(task);
-        renderClient();
-      };
-      startRow.appendChild(startInput);
-      form.appendChild(startRow);
+    if(task.structureRelation==="pre" || task.structureRelation==="parallel"){
+      addDetail("Límite temprano", task.limitEarlyMin!=null ? toHHMM(task.limitEarlyMin) : "Sin definir");
+    }else if(task.structureRelation==="post"){
+      addDetail("Límite tarde", task.limitLateMin!=null ? toHHMM(task.limitLateMin) : "Sin definir");
     }
-
-    const locRow=el("div","field-row");
-    locRow.appendChild(el("label",null, task.actionType===ACTION_TYPE_TRANSPORT?"Destino":"Localización"));
-    const locSelect=el("select","input");
-    const optEmpty=el("option",null,"- seleccionar -"); optEmpty.value=""; locSelect.appendChild(optEmpty);
-    (state.locations||[]).forEach(loc=>{
-      const opt=el("option",null,loc.nombre||"Localización"); opt.value=loc.id; if(loc.id===task.locationId) opt.selected=true; locSelect.appendChild(opt);
-    });
-    if(task.actionType===ACTION_TYPE_TRANSPORT && task.locationApplies!==true){
-      task.locationApplies = true;
-    }
-    const locationDisabled = task.actionType!==ACTION_TYPE_TRANSPORT && task.locationApplies!==true;
-    locSelect.disabled = locationDisabled;
-    locSelect.onchange=()=>{ task.locationId = locSelect.value||null; touchTask(task); renderClient(); };
-    locRow.appendChild(locSelect);
-    if(task.actionType!==ACTION_TYPE_TRANSPORT){
-      const locToggle=el("label","check");
-      const chk=el("input"); chk.type="checkbox"; chk.checked=!task.locationApplies;
-      chk.onchange=()=>{ task.locationApplies = !chk.checked; if(!task.locationApplies) task.locationId=null; touchTask(task); renderClient(); };
-      locToggle.appendChild(chk);
-      locToggle.appendChild(el("span",null,"Sin localización"));
-      locRow.appendChild(locToggle);
-    }else{
-      const flow=transportFlowForTask(task);
-      const originName=locationNameById(flow.origin) || "Sin origen";
-      const destName=locationNameById(flow.destination) || "Sin destino";
-      locRow.appendChild(el("div","mini",`Origen → ${originName} · Destino → ${destName}`));
-    }
-    form.appendChild(locRow);
 
     if(task.actionType===ACTION_TYPE_TRANSPORT){
-      if(!task.vehicleId){
-        const def=defaultVehicleId();
-        if(def){
-          task.vehicleId=def;
-          touchTask(task);
-        }
+      const flow=transportFlowForTask(task);
+      addDetail("Origen", locationNameById(flow.origin) || "Sin origen");
+      addDetail("Destino", locationNameById(flow.destination) || "Sin destino");
+      const vehName=(state.vehicles||[]).find(v=>v.id===task.vehicleId)?.nombre || "Sin vehículo";
+      addDetail("Vehículo", vehName);
+    }else{
+      let locationText="Sin localización";
+      if(task.locationApplies===false){
+        locationText="No aplica";
+      }else if(task.locationId){
+        locationText=locationNameById(task.locationId) || "Sin localización";
       }
-      const vehicleRow=el("div","field-row");
-      vehicleRow.appendChild(el("label",null,"Vehículo"));
-      const vehicleSelect=el("select","input");
-      const vehEmpty=el("option",null,"- seleccionar -"); vehEmpty.value=""; vehicleSelect.appendChild(vehEmpty);
-      (state.vehicles||[]).forEach(veh=>{
-        const opt=el("option",null,veh.nombre||"Vehículo"); opt.value=veh.id; if(veh.id===task.vehicleId) opt.selected=true; vehicleSelect.appendChild(opt);
-      });
-      vehicleSelect.onchange=()=>{ task.vehicleId = vehicleSelect.value||null; touchTask(task); };
-      vehicleRow.appendChild(vehicleSelect);
-      form.appendChild(vehicleRow);
+      addDetail("Localización", locationText);
     }
 
-    const notesRow=el("div","field-row");
-    notesRow.appendChild(el("label",null,"Notas"));
-    const notes=el("textarea","input"); notes.rows=4; notes.value=task.comentario||"";
-    notes.oninput=()=>{ task.comentario=notes.value; };
-    notes.onblur=()=>{ touchTask(task); };
-    notesRow.appendChild(notes);
-    form.appendChild(notesRow);
+    if(task.comentario && task.comentario.trim()){
+      const note=el("div","detail-row");
+      note.appendChild(el("span","detail-label","Notas"));
+      note.appendChild(el("span","detail-value detail-note",task.comentario.trim()));
+      details.appendChild(note);
+    }
 
-    center.appendChild(form);
+    center.appendChild(details);
     center.appendChild(renderStaffPicker(task));
-
-    const danger=el("button","btn danger", "Eliminar tarea");
-    danger.onclick=()=>{
-      if(confirm("¿Eliminar esta tarea y sus dependientes?")){
-        const parentId=task.structureParentId;
-        deleteTask(task.id);
-        if(parentId){
-          selectTask(parentId);
-        }else{
-          const next=getTaskList()[0];
-          selectTask(next?next.id:null);
-        }
-        renderClient();
-      }
-    };
-    const actions=el("div","task-actions");
-    actions.appendChild(danger);
-    center.appendChild(actions);
 
     grid.appendChild(renderNexoArea(task,"pre","Pretareas","top"));
     grid.appendChild(renderNexoArea(task,"parallel","Concurrencia","left"));
@@ -1078,12 +993,13 @@
     const isCatalogMount = catalogTarget && root === catalogTarget;
     root.innerHTML="";
     const screen=el("div","client-screen");
-    const timeline=el("div","client-timeline");
-    renderTimeline(timeline, selectedId);
-    screen.appendChild(timeline);
     root.appendChild(screen);
 
     if(isCatalogMount){
+      const timeline=el("div","client-timeline");
+      renderFixedTimeline(timeline, selectedId);
+      screen.appendChild(timeline);
+
       const layout=el("div","client-layout");
       const catalog=el("div","task-catalog");
       const card=el("div","task-card");
@@ -1091,9 +1007,13 @@
       layout.appendChild(card);
       screen.appendChild(layout);
 
-      renderCatalog(catalog, visible.length?visible:tasks, selectedId);
+      renderCatalog(catalog, tasks, selectedId);
       renderTaskCard(card, selectedTask);
     }else{
+      const timeline=el("div","client-timeline");
+      renderTimeline(timeline, selectedId);
+      screen.appendChild(timeline);
+
       const info=el("div","client-info");
       info.appendChild(el("p",null,"Gestiona los detalles completos de las tareas desde el Catálogo de Tareas."));
       screen.appendChild(info);


### PR DESCRIPTION
## Summary
- replace the catalog timeline with a read-only customer schedule using existing task data
- collapse the catalog task list into a single column and show time and location metadata per task
- rework the task inspector to present read-only details plus staff assignment while keeping relationship navigation, and adjust styles for the new layout

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d5c5b3e530832a820cd1effb626748