### PR TITLE
Adjust pretask level layout order

### DIFF
--- a/event-planer-main/assets/new-ui.js
+++ b/event-planer-main/assets/new-ui.js
@@ -1163,9 +1163,9 @@
       state.project.view.pretaskEditorId = null;
     }
     const grid=el("div","pretask-grid");
-    grid.appendChild(renderPretaskRow(task,1,level1,[task]));
-    grid.appendChild(renderPretaskRow(task,2,level2,level1));
     grid.appendChild(renderPretaskRow(task,3,level3,level2));
+    grid.appendChild(renderPretaskRow(task,2,level2,level1));
+    grid.appendChild(renderPretaskRow(task,1,level1,[task]));
     area.appendChild(grid);
     return area;
   };


### PR DESCRIPTION
## Summary
- reorder the pretask level rows in the catalog so level 3 appears at the top and level 1 at the bottom

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5d9353904832a8a770ea1637c3c51