### PR TITLE
Improve pretask duration editing

### DIFF
--- a/event-planer-main/assets/app.css
+++ b/event-planer-main/assets/app.css
@@ -200,6 +200,7 @@ table.matlist td.act{width:120px}
 .pretask-field-label{font-size:.7rem;letter-spacing:.08em;text-transform:uppercase;color:#c4b5fd}
 .pretask-input{width:100%}
 .pretask-duration{display:flex;align-items:center;gap:.5rem}
+.pretask-duration-input{width:72px;text-align:center;border-radius:.45rem;border:1px solid #1f2937;background:#111827;color:#e5e7eb;padding:.25rem .35rem;font-variant-numeric:tabular-nums}
 .pretask-duration-value{font-variant-numeric:tabular-nums;font-size:1rem}
 .pretask-step{width:32px;height:32px;border-radius:999px;border:1px solid #1f2937;background:#111827;color:#e5e7eb;display:flex;align-items:center;justify-content:center;font-size:1.1rem;cursor:pointer}
 .pretask-step:disabled{opacity:.35;cursor:not-allowed}


### PR DESCRIPTION
## Summary
- show the current pretask duration in a numeric field with a minute label
- allow changing the duration from the editor using +/- buttons or direct input
- update styles for the new duration input control

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5de4d37d0832aa3e57d1cb391225c