### PR TITLE
Enable configurable pretask durations and time windows

### DIFF
--- a/event-planer-main/assets/app.css
+++ b/event-planer-main/assets/app.css
@@ -208,6 +208,10 @@ table.matlist td.act{width:120px}
 .pretask-time{display:flex;flex-direction:column;gap:.25rem}
 .pretask-time-label{font-size:.7rem;color:#94a3b8}
 .pretask-time-input{width:100%}
+.pretask-time-toggle{display:flex;align-items:center;gap:.35rem;color:#cbd5f5;font-size:.7rem;letter-spacing:.05em;text-transform:uppercase;cursor:pointer}
+.pretask-time-checkbox{width:16px;height:16px;accent-color:#60a5fa}
+.pretask-time-input-wrap[hidden]{display:none}
+.pretask-time-note{grid-column:1/-1;font-size:.7rem;color:#64748b;padding:.1rem 0}
 .pretask-arrow{display:flex;align-items:center;gap:.35rem;font-size:.75rem;color:#94a3b8;padding:0 .1rem}
 .pretask-arrow-icon{font-size:.85rem;color:#cbd5f5}
 .nexo-list{display:flex;flex-wrap:wrap;gap:.45rem}


### PR DESCRIPTION
## Summary
- allow pre-task durations to be changed reliably by wiring the numeric control back to state and refreshing its display
- add opt-in checkboxes for minimum and maximum time windows so the inputs stay hidden until enabled and show a "Sin restricciones" note by default
- persist the new availability flags across the pre-task UI, status chips and detail panes so optional limits no longer block task completion

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d5e21ba948832a8700409b1e879488