### PR TITLE
Allow editing pretask durations in catalog

### DIFF
--- a/event-planer-main/assets/new-ui.js
+++ b/event-planer-main/assets/new-ui.js
@@ -75,7 +75,12 @@
     task.endMin = toNumberOrNull(task.endMin);
     task.durationMin = Number.isFinite(Number(task.durationMin)) ? Math.max(5, Math.round(Number(task.durationMin))) : null;
     if(task.startMin != null && task.endMin != null){
-      task.durationMin = Math.max(5, task.endMin - task.startMin);
+      const computedDuration = Math.max(5, task.endMin - task.startMin);
+      if(task.structureRelation === "pre"){
+        if(!Number.isFinite(Number(task.durationMin))) task.durationMin = computedDuration;
+      }else{
+        task.durationMin = computedDuration;
+      }
     }
     if(task.durationMin == null) task.durationMin = 60;
     task.limitEarlyMin = toNumberOrNull(task.limitEarlyMin);


### PR DESCRIPTION
## Summary
- stop recalculating pretask duration from start/end times when defaults are applied
- keep the manually entered duration unless it is missing, so catalog edits persist

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d5e5487c58832aa164d981c6b3e7bd