### PR TITLE
Show pretask range and duration in catalog pretasks

### DIFF
--- a/event-planer-main/assets/app.css
+++ b/event-planer-main/assets/app.css
@@ -216,6 +216,7 @@ table.matlist td.act{width:120px}
 .pretask-arrow-icon{font-size:.85rem;color:#cbd5f5}
 .nexo-list{display:flex;flex-wrap:wrap;gap:.45rem}
 .nexo-item{display:flex;flex-direction:column;gap:.2rem;align-items:flex-start;background:#111827;border:1px solid #1f2937;border-radius:.65rem;padding:.45rem .6rem;cursor:pointer;max-width:100%}
+.nexo-range{color:#cbd5f5;font-size:.85rem;font-variant-numeric:tabular-nums}
 .nexo-item .mini{color:#94a3b8;font-size:.8rem}
 .nexo-item.pending{border-color:#f97316;color:#fdba74}
 .nexo-item.active{border-color:#3b82f6;color:#bfdbfe}

--- a/event-planer-main/assets/new-ui.js
+++ b/event-planer-main/assets/new-ui.js
@@ -993,6 +993,25 @@
     return "Sin datos";
   };
 
+  const pretaskRangeLabel = (task)=>{
+    const hasLower = task.limitEarlyMinEnabled && Number.isFinite(task.limitEarlyMin);
+    const hasUpper = task.limitLateMinEnabled && Number.isFinite(task.limitLateMin);
+    if(hasLower && hasUpper){
+      const lower=toHHMM(task.limitEarlyMin);
+      const upper=toHHMM(task.limitLateMin);
+      return lower===upper ? lower : `${lower} – ${upper}`;
+    }
+    if(hasLower) return `Desde ${toHHMM(task.limitEarlyMin)}`;
+    if(hasUpper) return `Hasta ${toHHMM(task.limitLateMin)}`;
+    if(task.limitEarlyMinEnabled || task.limitLateMinEnabled) return "Sin definir";
+    return "Por defecto";
+  };
+
+  const pretaskDurationLabel = (task)=>{
+    if(Number.isFinite(task.durationMin)) return `${task.durationMin} min`;
+    return "Sin duración";
+  };
+
   const isPretask = (t)=>t && t.structureRelation === "pre";
 
   const collectPretaskLevels = (task)=>{
@@ -1267,7 +1286,11 @@
       renderClient();
     };
     item.appendChild(el("div","nexo-name",labelForTask(task)));
-    item.appendChild(el("div","mini",relationInfo(task)));
+    const rangeLabel=pretaskRangeLabel(task);
+    if(rangeLabel){
+      item.appendChild(el("div","nexo-range",rangeLabel));
+    }
+    item.appendChild(el("div","mini",pretaskDurationLabel(task)));
     card.appendChild(item);
 
     const linkRow=el("div","pretask-arrow");


### PR DESCRIPTION
## Summary
- display the configured time range for each pretarea card in the catalog simple view and fall back to "Por defecto" when no limits are enabled
- keep the duration as a dedicated mini line under each card and add styling for the new range row

## Testing
- no automated tests were run (static frontend project)


------
https://chatgpt.com/codex/tasks/task_e_68d5ebf20ebc832aaf8908a01a0b4a68