### PR TITLE
Mostrar localización en tarjetas de pretareas

### DIFF
--- a/event-planer-main/assets/app.css
+++ b/event-planer-main/assets/app.css
@@ -196,7 +196,7 @@ table.matlist td.act{width:120px}
 .pretask-row-body{display:flex;flex-wrap:wrap;gap:.45rem}
 .pretask-list{display:flex;flex-wrap:wrap;gap:.45rem;width:100%}
 .pretask-card{display:flex;flex-direction:column;gap:.4rem;min-width:180px;max-width:100%}
-.pretask-card .nexo-item{width:100%}
+.pretask-card .nexo-item{width:100%;border-color:#f97316;color:#fdba74}
 .pretask-card.open .nexo-item{border-color:#2563eb}
 .pretask-editor{display:none;flex-direction:column;gap:.55rem;padding:.6rem;border:1px solid #1f2937;border-radius:.6rem;background:#0f172a}
 .pretask-card.open .pretask-editor{display:flex}

--- a/event-planer-main/assets/new-ui.js
+++ b/event-planer-main/assets/new-ui.js
@@ -1405,6 +1405,19 @@
       item.appendChild(el("div","nexo-range",rangeLabel));
     }
     item.appendChild(el("div","mini",pretaskDurationLabel(task)));
+
+    let locationLabel="";
+    if(task.actionType===ACTION_TYPE_TRANSPORT){
+      const flow=transportFlowForTask(task);
+      const originName=locationNameById(flow.origin) || "Sin origen";
+      const destName=locationNameById(flow.destination) || "Sin destino";
+      locationLabel=`${originName} → ${destName}`;
+    }else if(task.locationApplies===false){
+      locationLabel="No aplica";
+    }else{
+      locationLabel=locationNameById(task.locationId) || "Sin localización";
+    }
+    item.appendChild(el("div","mini",locationLabel));
     card.appendChild(item);
 
     const linkRow=el("div","pretask-arrow");


### PR DESCRIPTION
## Summary
- display the location information on pretask cards within the simplified catalog view
- ensure pretask cards keep their orange styling even after selecting a location

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5f69df788832a8465c272f5a21ca5