### PR TITLE
Enable post-task cards to expand editors

### DIFF
--- a/event-planer-main/assets/app.css
+++ b/event-planer-main/assets/app.css
@@ -199,7 +199,7 @@ table.matlist td.act{width:120px}
 .pretask-card .nexo-item{width:100%;border-color:#f97316;color:#fdba74}
 .pretask-card.open .nexo-item{border-color:#2563eb}
 .pretask-editor{display:none;flex-direction:column;gap:.55rem;padding:.6rem;border:1px solid #1f2937;border-radius:.6rem;background:#0f172a}
-.pretask-card.open .pretask-editor{display:flex}
+.pretask-card.open .pretask-editor,.posttask-card.open .pretask-editor{display:flex}
 .pretask-field{display:flex;flex-direction:column;gap:.3rem}
 .pretask-field-label{font-size:.7rem;letter-spacing:.08em;text-transform:uppercase;color:#c4b5fd}
 .pretask-input{width:100%}


### PR DESCRIPTION
## Summary
- ensure the shared task editor component becomes visible when opening a posttarea card
- reuse the existing display rule so both pre- and post-task cards expand their editors correctly

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d680ae6bdc832a8ecb7b4069c69610