### PR TITLE
Fix posttask editors keeping manual duration and time ranges

### DIFF
--- a/event-planer-main/assets/new-ui.js
+++ b/event-planer-main/assets/new-ui.js
@@ -40,6 +40,7 @@
   };
 
   const toNumberOrNull = (value)=>{
+    if(value===null || value===undefined || value==="") return null;
     const n = Number(value);
     return Number.isFinite(n) ? n : null;
   };


### PR DESCRIPTION
## Summary
- avoid normalising null/empty numeric values to 0 when preparing task data
- keep posttask duration and time range inputs editable instead of reverting to 5 minutes

## Testing
- Manual verification of posttask duration and time range editing in the catalog view

------
https://chatgpt.com/codex/tasks/task_e_68d6835e0770832a9234e45442c1fbd2