### PR TITLE
Add increment/decrement controls for material quantities

### DIFF
--- a/event-planer-main/assets/app.css
+++ b/event-planer-main/assets/app.css
@@ -292,6 +292,10 @@ table.matlist td.act{width:120px}
 .material-field{display:flex;flex-direction:column;gap:.25rem;font-size:.85rem;color:#94a3b8}
 .material-field-label{font-size:.75rem;letter-spacing:.08em;text-transform:uppercase}
 .material-field.qty input{font-variant-numeric:tabular-nums}
+.material-qty-controls{display:flex;align-items:center;gap:.5rem}
+.material-qty-controls input{flex:0 0 4rem;text-align:center}
+.material-qty-btn{background:#111827;border:1px solid #1f2937;color:#e5e7eb;width:2rem;height:2rem;border-radius:.5rem;display:flex;align-items:center;justify-content:center;font-size:1.1rem;line-height:1;cursor:pointer}
+.material-qty-btn:disabled{opacity:.45;cursor:not-allowed}
 .material-actions{display:flex;align-items:center;justify-content:flex-end;flex-wrap:wrap;gap:.4rem}
 .material-actions .btn{white-space:nowrap;max-width:100%}
 .materials-catalog{display:flex;flex-direction:column;gap:.75rem;padding-top:.5rem;border-top:1px solid rgba(148,163,184,.2)}


### PR DESCRIPTION
## Summary
- add stepper controls to the material quantity editor in the task catalog
- normalize and clamp material quantities so they always stay at one unit or more
- style the new controls so the +/- buttons align with the existing form layout

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d69e9142a4832ab9f8f902488b57a0