### PR TITLE
Fix material quantity editing layout

### DIFF
--- a/event-planer-main/assets/app.css
+++ b/event-planer-main/assets/app.css
@@ -293,6 +293,7 @@ table.matlist td.act{width:120px}
 .material-field-label{font-size:.75rem;letter-spacing:.08em;text-transform:uppercase}
 .material-field.qty input{font-variant-numeric:tabular-nums}
 .material-qty-controls{display:flex;align-items:center;gap:.5rem}
+.material-qty-buttons{display:flex;flex-direction:column;gap:.35rem}
 .material-qty-controls input{flex:0 0 4rem;text-align:center}
 .material-qty-btn{background:#111827;border:1px solid #1f2937;color:#e5e7eb;width:2rem;height:2rem;border-radius:.5rem;display:flex;align-items:center;justify-content:center;font-size:1.1rem;line-height:1;cursor:pointer}
 .material-qty-btn:disabled{opacity:.45;cursor:not-allowed}

--- a/event-planer-main/assets/new-ui.js
+++ b/event-planer-main/assets/new-ui.js
@@ -1248,17 +1248,19 @@
         const qtyWrap=el("label","material-field qty");
         qtyWrap.appendChild(el("span","material-field-label","Cantidad"));
         const qtyControls=el("div","material-qty-controls");
+        const buttonGroup=el("div","material-qty-buttons");
         const decrementBtn=el("button","material-qty-btn","-");
         decrementBtn.type="button";
+        const incrementBtn=el("button","material-qty-btn","+");
+        incrementBtn.type="button";
+        buttonGroup.appendChild(decrementBtn);
+        buttonGroup.appendChild(incrementBtn);
         const qtyInput=el("input","input");
         qtyInput.type="number";
         qtyInput.min="1";
         qtyInput.step="1";
-        const incrementBtn=el("button","material-qty-btn","+");
-        incrementBtn.type="button";
-        qtyControls.appendChild(decrementBtn);
+        qtyControls.appendChild(buttonGroup);
         qtyControls.appendChild(qtyInput);
-        qtyControls.appendChild(incrementBtn);
         qtyWrap.appendChild(qtyControls);
         row.appendChild(qtyWrap);
 
@@ -1269,6 +1271,9 @@
         };
 
         const commitQty = (value, shouldRender=false)=>{
+          if(typeof value === "string" && value.trim()===""){
+            return;
+          }
           const next = normalizeQuantity(value);
           const prev = normalizeQuantity(mat.cantidad);
           if(prev !== next){


### PR DESCRIPTION
## Summary
- place the material quantity increment and decrement buttons together on the left side of each row while keeping the remove button on the right
- ensure the quantity editor accepts multi-unit values by avoiding the reset to one while the input is temporarily blank during typing

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6a14357e8832aa6facabcaa2fa1fb