### PR TITLE
Add lock toggle to client task catalog

### DIFF
--- a/event-planer-main/assets/app.css
+++ b/event-planer-main/assets/app.css
@@ -152,10 +152,17 @@ table.matlist td.act{width:120px}
 .catalog-section{background:#0f172a;border:1px solid #1f2937;border-radius:.75rem;padding:.8rem;display:flex;flex-direction:column;gap:.55rem}
 .catalog-title{font-size:.9rem;font-weight:600;letter-spacing:.05em;text-transform:uppercase;color:#94a3b8}
 .catalog-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(210px,1fr));gap:.6rem}
-.catalog-item{display:flex;flex-direction:column;gap:.35rem;align-items:flex-start;background:#0b1220;border:1px solid #1f2937;border-radius:.75rem;padding:.7rem .8rem;color:#e5e7eb;text-align:left;cursor:pointer}
+.catalog-item{display:flex;flex-direction:column;gap:.35rem;align-items:flex-start;background:#0b1220;border:1px solid #1f2937;border-radius:.75rem;padding:.7rem .8rem;color:#e5e7eb;text-align:left;cursor:pointer;transition:border-color .2s ease,box-shadow .2s ease}
 .catalog-item .mini{margin-top:.1rem}
 .catalog-item.active{border-color:#3b82f6;box-shadow:0 0 0 1px #3b82f6}
 .catalog-item:hover{border-color:#3b82f6}
+.catalog-item.locked{border-color:#22c55e;box-shadow:0 0 0 1px rgba(34,197,94,.35)}
+.catalog-item.locked .catalog-name{color:#bbf7d0}
+.catalog-title-row{width:100%;display:flex;align-items:center;justify-content:space-between;gap:.5rem}
+.catalog-lock{width:1.75rem;height:1.75rem;display:flex;align-items:center;justify-content:center;border-radius:999px;border:1px solid #1f2937;background:rgba(15,23,42,.6);color:#94a3b8;font-size:.9rem;cursor:pointer;transition:all .2s ease}
+.catalog-lock:hover{border-color:#3b82f6;color:#bfdbfe;background:rgba(59,130,246,.15)}
+.catalog-lock.is-locked{border-color:#16a34a;color:#4ade80;background:rgba(22,163,74,.2)}
+.catalog-item.locked .catalog-lock{border-color:#16a34a;color:#4ade80;background:rgba(22,163,74,.25)}
 .catalog-name{font-size:1rem;font-weight:600}
 .catalog-meta{display:flex;gap:.45rem;font-size:.8rem;color:#94a3b8}
 .catalog-time{font-variant-numeric:tabular-nums}
@@ -169,6 +176,16 @@ table.matlist td.act{width:120px}
 .catalog-base .mini{color:#94a3b8}
 .catalog-base-view{background:#0f172a;border:1px solid #1f2937;border-radius:.9rem;padding:1rem;overflow:auto}
 .catalog-base-view .client-screen{gap:1.5rem}
+.task-editor.locked .task-title{color:#bbf7d0}
+.task-editor.locked .lock-notice{margin-top:.6rem;padding:.6rem .75rem;border:1px solid rgba(34,197,94,.4);background:rgba(21,128,61,.25);border-radius:.6rem;color:#bbf7d0;font-size:.85rem}
+.lock-notice{margin-top:.6rem;padding:.6rem .75rem;border:1px solid rgba(59,130,246,.3);background:rgba(59,130,246,.08);border-radius:.6rem;color:#cbd5f5;font-size:.85rem}
+.nexo-area.locked{opacity:.9}
+.nexo-area.locked .nexo-item,.nexo-area.locked .btn,.materials-editor .btn.locked,.staff-section .staff-toggle.locked{cursor:not-allowed}
+.nexo-area.locked .nexo-item.locked,.staff-section .staff-toggle.locked,.materials-editor .btn.locked{opacity:.55}
+.nexo-area.locked .btn.locked{pointer-events:none}
+.nexo-item.locked{cursor:not-allowed;pointer-events:none;opacity:.6}
+.staff-toggle.locked{cursor:not-allowed;pointer-events:none;opacity:.6}
+.btn.locked{cursor:not-allowed;pointer-events:none;opacity:.6}
 .task-editor{display:flex;flex-direction:column;gap:1.2rem}
 .nexo-grid{display:grid;grid-template-areas:"top top top" "left center right" "bottom bottom bottom";grid-template-columns:minmax(220px,260px) minmax(320px,1fr) minmax(240px,280px);gap:1rem}
 .nexo-area{background:#0f172a;border:1px solid #1f2937;border-radius:.9rem;padding:.8rem;display:flex;flex-direction:column;gap:.6rem;position:relative}
@@ -265,6 +282,7 @@ table.matlist td.act{width:120px}
 .status-chip{padding:.25rem .6rem;border-radius:.65rem;font-size:.75rem;text-transform:uppercase;letter-spacing:.05em}
 .status-chip.ok{background:#166534;color:#dcfce7}
 .status-chip.warn{background:#7f1d1d;color:#fee2e2}
+.status-chip.lock{background:#14532d;color:#bbf7d0}
 .task-breadcrumb{display:flex;flex-wrap:wrap;gap:.35rem;align-items:center;font-size:.85rem}
 .crumb{background:#111827;border:1px solid #1f2937;color:#e5e7eb;padding:.25rem .6rem;border-radius:.55rem;cursor:pointer}
 .crumb:disabled{opacity:.6;cursor:default}


### PR DESCRIPTION
## Summary
- add a lock toggle to each client task in the catalog so completed work can be marked as read-only
- prevent edits to locked tasks across staff, materials, pre/post/parallel task flows, and display a lock notice for clarity
- update catalog and detail styling to highlight locked tasks and the new control

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6ad9bb36c832a9b951b5641feec7a