### PR TITLE
Add schedule metrics and controls

### DIFF
--- a/event-planer-main/assets/app.css
+++ b/event-planer-main/assets/app.css
@@ -305,6 +305,22 @@ table.matlist td.act{width:120px}
 .material-summary-qty{font-weight:600}
 .material-summary-row.pending .material-summary-name{color:#fca5a5}
 .warn-text{color:#fca5a5}
+.schedule-controls{display:flex;flex-wrap:wrap;align-items:center;gap:.75rem;margin-bottom:1rem}
+.schedule-controls .btn{flex:0 0 auto}
+.schedule-params{display:flex;flex-direction:column;gap:.35rem;min-width:220px}
+.schedule-params .mini{color:#94a3b8}
+.schedule-params .input{max-width:140px}
+.schedule-tabs{display:flex;flex-wrap:wrap;gap:.5rem;margin:1rem 0}
+.schedule-body{display:flex;flex-direction:column;gap:1rem}
+.schedule-table{width:100%;border-collapse:collapse;font-size:.85rem}
+.schedule-table th,.schedule-table td{padding:.45rem .6rem;text-align:left;border-bottom:1px solid rgba(148,163,184,.2)}
+.schedule-table th{font-weight:600;color:#94a3b8;font-size:.75rem;text-transform:uppercase;letter-spacing:.05em}
+.schedule-metrics,.schedule-global{margin-top:1rem}
+.schedule-metrics .mini,.schedule-global .mini{font-weight:600;color:#cbd5f5;margin-bottom:.35rem}
+.schedule-metrics-table{width:100%;border-collapse:collapse;font-size:.8rem}
+.schedule-metrics-table th,.schedule-metrics-table td{padding:.3rem .5rem;text-align:left}
+.schedule-metrics-table th{color:#94a3b8;font-weight:600;font-size:.75rem;text-transform:uppercase;letter-spacing:.05em}
+.schedule-metrics-table td{color:#e5e7eb;font-variant-numeric:tabular-nums}
 .material-rows{display:flex;flex-direction:column;gap:.5rem}
 .material-row{position:relative;display:grid;grid-template-columns:minmax(0,1fr) auto;gap:.75rem;align-items:flex-start;background:#0b1220;border:1px solid #1f2937;border-radius:.6rem;padding:1rem;padding-right:3rem}
 .material-field{display:flex;flex-direction:column;gap:.25rem;font-size:.85rem;color:#94a3b8}

--- a/event-planer-main/assets/js/state.js
+++ b/event-planer-main/assets/js/state.js
@@ -47,6 +47,12 @@
     st.scheduleMeta.warningsByStaff=st.scheduleMeta.warningsByStaff||{};
     st.scheduleMeta.globalWarnings=st.scheduleMeta.globalWarnings||[];
     if(typeof st.scheduleMeta.activeStaffId==="undefined") st.scheduleMeta.activeStaffId=null;
+    st.scheduleMeta.metricsByStaff=st.scheduleMeta.metricsByStaff||{};
+    st.scheduleMeta.globalMetrics=st.scheduleMeta.globalMetrics||{};
+    st.scheduleMeta.parameters=st.scheduleMeta.parameters||{};
+    if(!Number.isFinite(Number(st.scheduleMeta.parameters.earlyStartThreshold))){
+      st.scheduleMeta.parameters.earlyStartThreshold = 7*60;
+    }
     st.project=st.project||{nombre:"Proyecto",fecha:"",tz:"Europe/Madrid",updatedAt:"",view:{}}; st.project.view=st.project.view||{};
     st.project.view.lastTab=st.project.view.lastTab||"CLIENTE"; st.project.view.subGantt=st.project.view.subGantt||"Gantt"; st.project.view.selectedIndex=st.project.view.selectedIndex||{};
     if(!st.sessions.CLIENTE) st.sessions.CLIENTE=[];


### PR DESCRIPTION
## Summary
- extend schedule metadata to store per-staff metrics, global metrics, and configurable parameters
- enhance schedule generation to compute workload statistics, early-start warnings, and expose parameter controls in the catalog
- style the new scheduling panels to present global and per-staff summaries

## Testing
- No automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68daf91aa504832a9649c14fc7e78818