### PR TITLE
Add AI-powered schedule generation option

### DIFF
--- a/event-planer-main/assets/app.css
+++ b/event-planer-main/assets/app.css
@@ -4,6 +4,7 @@ html,body{height:100%;margin:0;background:#0b1220;color:#e5e7eb;font:14px/1.4 ui
 .btn{background:#111827;border:1px solid #1f2937;color:#e5e7eb;padding:.45rem .7rem;border-radius:.6rem;cursor:pointer}
 .btn:disabled{opacity:.45;cursor:not-allowed}
 .btn.primary{background:#047857;border-color:#059669}
+.btn.secondary{background:#1f2937;border-color:#374151;color:#f8fafc}
 .btn.small{font-size:12px;padding:.25rem .5rem}
 .btn.danger{background:#7f1d1d;border-color:#991b1b}
 .btn.chip{background:#e5e7eb;color:#111827;border-color:#e5e7eb}


### PR DESCRIPTION
## Summary
- add an AI-based schedule generation path in the catalog, including OpenAI request helpers and application of the returned plan
- surface the generation method/timestamp in the catalog controls and add a secondary button style for the AI action

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbbbea2e08832a81edc058fcc256b6