### PR TITLE
Remove manual schedule generator and update AI scheduling criteria

### DIFF
--- a/event-planer-main/assets/js/state.js
+++ b/event-planer-main/assets/js/state.js
@@ -309,9 +309,6 @@
     st.scheduleMeta.metricsByStaff=st.scheduleMeta.metricsByStaff||{};
     st.scheduleMeta.globalMetrics=st.scheduleMeta.globalMetrics||{};
     st.scheduleMeta.parameters=st.scheduleMeta.parameters||{};
-    if(!Number.isFinite(Number(st.scheduleMeta.parameters.earlyStartThreshold))){
-      st.scheduleMeta.parameters.earlyStartThreshold = 7*60;
-    }
     st.project=st.project||{nombre:"Proyecto",fecha:"",tz:"Europe/Madrid",updatedAt:"",view:{}}; st.project.view=st.project.view||{};
     st.project.view.lastTab=st.project.view.lastTab||"CLIENTE"; st.project.view.subGantt=st.project.view.subGantt||"Gantt"; st.project.view.selectedIndex=st.project.view.selectedIndex||{};
     if(!st.sessions.CLIENTE) st.sessions.CLIENTE=[];


### PR DESCRIPTION
## Summary
- remove the legacy schedule generation engine and associated catalog controls, keeping only the AI workflow
- drop the early-start warning parameter from state handling and the catalog UI
- update the AI prompt and payload to instruct the model to start shifts as late as possible and minimize gaps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd3e6f1060832a8a1e0c7d20064ed3