### PR TITLE
Fix pretask default ranges for nested levels

### DIFF
--- a/event-planer-main/assets/new-ui.js
+++ b/event-planer-main/assets/new-ui.js
@@ -317,7 +317,7 @@
       const parent=getTaskParent(current);
       if(!parent) break;
       if(parent.structureRelation === "pre"){
-        if(parent.limitLateMinEnabled && Number.isFinite(parent.limitLateMin)){
+        if(Number.isFinite(parent.limitLateMin)){
           return roundToFive(clampToDay(parent.limitLateMin));
         }
         if(Number.isFinite(parent.startMin)){


### PR DESCRIPTION
## Summary
- ensure nested pretasks inherit the latest start boundary from their parent regardless of the parent's range toggle state
- allow level 2 and 3 pretasks to default their window based on linked task durations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd52bfc018832aad19ca109d5b3dcd