### PR TITLE
Ensure level 3 pretasks default to midnight

### DIFF
--- a/event-planer-main/assets/new-ui.js
+++ b/event-planer-main/assets/new-ui.js
@@ -290,11 +290,16 @@
   const inheritedPretaskLower = (task)=>{
     const visited=new Set();
     let current=task;
+    let depth=0;
     while(current){
       if(visited.has(current.id)) break;
       visited.add(current.id);
       const parent=getTaskParent(current);
       if(!parent || parent.structureRelation !== "pre") break;
+      depth++;
+      if(depth>=2){
+        return null;
+      }
       if(parent.limitEarlyMinEnabled && Number.isFinite(parent.limitEarlyMin)){
         return roundToFive(clampToDay(parent.limitEarlyMin));
       }


### PR DESCRIPTION
## Summary
- avoid propagating lower-bound constraints beyond the immediate parent when computing default pretask ranges so level 3 pretasks can start at 00:00

## Testing
- Manual verification in the browser

------
https://chatgpt.com/codex/tasks/task_e_68dd5553d308832ab77dec646d695311