### PR TITLE
Add catalog map with travel distance calculations

### DIFF
--- a/event-planer-main/assets/app.bundle.js
+++ b/event-planer-main/assets/app.bundle.js
@@ -31,6 +31,7 @@
   if(!root.state){
     root.state = {
       project:{ nombre:"Proyecto", fecha:"", tz:"Europe/Madrid", updatedAt:"", view:{ lastTab:"CLIENTE", subGantt:"Gantt", selectedIndex:{} } },
+      integrations:{ googleMaps:{ apiKey:"" } },
       locations:[
         { id:"L_STAGE", nombre:"Escenario principal", lat:"41.3870", lng:"2.1701" },
         { id:"L_STORAGE", nombre:"Almacén central", lat:"41.3865", lng:"2.1698" },
@@ -1227,6 +1228,560 @@
   "use strict";
   const ACTION_TYPE_TRANSPORT = window.ACTION_TYPE_TRANSPORT || "TRANSPORTE";
   const ACTION_TYPE_NORMAL = window.ACTION_TYPE_NORMAL || "NORMAL";
+  const TILE_SIZE = 256;
+  const MIN_ZOOM = 2;
+  const MAX_ZOOM = 18;
+  const DEFAULT_MAP_VIEW = { lat: 40.4168, lng: -3.7038, zoom: 5 };
+  const WALKING_SPEED_KMPH = 4.5;
+  const DRIVING_SPEED_KMPH = 45;
+  const GOOGLE_KEY_STORAGE = "eventplan.googleMapsKey";
+
+  const toNumber = (value)=>{
+    const str = String(value ?? "").trim().replace(/,/g, ".");
+    if(!str) return NaN;
+    return Number(str);
+  };
+
+  const clampLatLng = (lat, lng)=>{
+    const clampedLat = Math.max(-85.0511, Math.min(85.0511, Number.isFinite(lat) ? lat : 0));
+    let normLng = Number.isFinite(lng) ? lng : 0;
+    normLng = ((normLng + 180) % 360 + 360) % 360 - 180;
+    return { lat: clampedLat, lng: normLng };
+  };
+
+  const latLngToPixel = (lat, lng, zoom)=>{
+    const scale = TILE_SIZE * Math.pow(2, zoom);
+    const sin = Math.sin(lat * Math.PI / 180);
+    const x = (lng + 180) / 360 * scale;
+    const y = (0.5 - Math.log((1 + sin) / (1 - sin)) / (4 * Math.PI)) * scale;
+    return { x, y };
+  };
+
+  const pixelToLatLng = (x, y, zoom)=>{
+    const scale = TILE_SIZE * Math.pow(2, zoom);
+    const lng = x / scale * 360 - 180;
+    const n = Math.PI - 2 * Math.PI * y / scale;
+    const lat = 180 / Math.PI * Math.atan(0.5 * (Math.exp(n) - Math.exp(-n)));
+    return { lat, lng };
+  };
+
+  const computeInitialView = (locations, width, height)=>{
+    if(!locations.length){
+      return { center:{ lat:DEFAULT_MAP_VIEW.lat, lng:DEFAULT_MAP_VIEW.lng }, zoom:DEFAULT_MAP_VIEW.zoom };
+    }
+    const lats = locations.map(l=>l.lat);
+    const lngs = locations.map(l=>l.lng);
+    const minLat = Math.min(...lats);
+    const maxLat = Math.max(...lats);
+    const minLng = Math.min(...lngs);
+    const maxLng = Math.max(...lngs);
+    let zoom = DEFAULT_MAP_VIEW.zoom;
+    for(let z=MAX_ZOOM; z>=MIN_ZOOM; z--){
+      const nw = latLngToPixel(maxLat, minLng, z);
+      const se = latLngToPixel(minLat, maxLng, z);
+      const dx = Math.abs(se.x - nw.x);
+      const dy = Math.abs(se.y - nw.y);
+      if(dx <= width && dy <= height){
+        zoom = z;
+        break;
+      }
+    }
+    return { center:{ lat:(minLat+maxLat)/2, lng:(minLng+maxLng)/2 }, zoom };
+  };
+
+  const projectPoint = (lat, lng, view)=>{
+    const zoom = view.zoom;
+    const centerPx = latLngToPixel(view.center.lat, view.center.lng, zoom);
+    const pointPx = latLngToPixel(lat, lng, zoom);
+    const world = TILE_SIZE * Math.pow(2, zoom);
+    let dx = pointPx.x - centerPx.x;
+    if(dx > world / 2) dx -= world;
+    if(dx < -world / 2) dx += world;
+    const dy = pointPx.y - centerPx.y;
+    return { x: view.width / 2 + dx, y: view.height / 2 + dy };
+  };
+
+  const haversineKm = (a, b)=>{
+    const R = 6371;
+    const toRad = (deg)=>deg * Math.PI / 180;
+    const dLat = toRad(b.lat - a.lat);
+    const dLng = toRad(b.lng - a.lng);
+    const lat1 = toRad(a.lat);
+    const lat2 = toRad(b.lat);
+    const sinLat = Math.sin(dLat / 2);
+    const sinLng = Math.sin(dLng / 2);
+    const h = sinLat * sinLat + sinLng * sinLng * Math.cos(lat1) * Math.cos(lat2);
+    const c = 2 * Math.atan2(Math.sqrt(h), Math.sqrt(Math.max(0, 1 - h)));
+    return R * c;
+  };
+
+  const estimateTimes = (distanceKm)=>{
+    if(!Number.isFinite(distanceKm)){
+      return { drive:null, walk:null };
+    }
+    const drive = (distanceKm / DRIVING_SPEED_KMPH) * 60;
+    const walk = (distanceKm / WALKING_SPEED_KMPH) * 60;
+    return { drive, walk };
+  };
+
+  const ensureGoogleConfig = ()=>{
+    state.integrations = state.integrations || {};
+    state.integrations.googleMaps = state.integrations.googleMaps || { apiKey:"" };
+    return state.integrations.googleMaps;
+  };
+
+  const loadGoogleApiKey = ()=>{
+    const cfg = ensureGoogleConfig();
+    if(cfg.apiKey) return cfg.apiKey;
+    try{
+      return localStorage.getItem(GOOGLE_KEY_STORAGE) || "";
+    }catch(err){
+      return "";
+    }
+  };
+
+  const persistGoogleApiKey = (key)=>{
+    const cfg = ensureGoogleConfig();
+    const trimmed = key.trim();
+    if(cfg.apiKey !== trimmed){
+      cfg.apiKey = trimmed;
+      touch();
+    }
+    try{
+      if(trimmed){
+        localStorage.setItem(GOOGLE_KEY_STORAGE, trimmed);
+      }else{
+        localStorage.removeItem(GOOGLE_KEY_STORAGE);
+      }
+    }catch(err){
+    }
+    return trimmed;
+  };
+
+  const formatDistance = (km)=>{
+    if(!Number.isFinite(km)) return "-";
+    if(km >= 100) return `${km.toFixed(0)} km`;
+    if(km >= 10) return `${km.toFixed(1)} km`;
+    return `${km.toFixed(2)} km`;
+  };
+
+  const formatDuration = (mins)=>{
+    if(!Number.isFinite(mins)) return "-";
+    const total = Math.max(0, Math.round(mins));
+    const h = Math.floor(total / 60);
+    const m = total % 60;
+    if(h && m) return `${h}h ${m}m`;
+    if(h) return `${h}h`;
+    return `${m}m`;
+  };
+
+  const buildSegments = (locations)=>{
+    const segments=[];
+    for(let i=0; i<locations.length-1; i++){
+      const from = locations[i];
+      const to = locations[i+1];
+      const distanceKm = haversineKm(from, to);
+      const { drive, walk } = estimateTimes(distanceKm);
+      segments.push({
+        id:`${from.id||i}_${to.id||i+1}`,
+        from,
+        to,
+        distanceKm,
+        durationDriveMin: drive,
+        durationWalkMin: walk,
+        provider:"estimate",
+        providerNote:"Estimación basada en distancia geodésica"
+      });
+    }
+    return segments;
+  };
+
+  const updateSegmentEstimates = (seg)=>{
+    if(!Number.isFinite(seg.distanceKm)) return;
+    const { drive, walk } = estimateTimes(seg.distanceKm);
+    if(!Number.isFinite(seg.durationDriveMin)) seg.durationDriveMin = drive;
+    if(!Number.isFinite(seg.durationWalkMin)) seg.durationWalkMin = walk;
+  };
+
+  const fetchDistanceMatrix = async (from, to, mode, apiKey)=>{
+    const params = new URLSearchParams({
+      units:"metric",
+      origins:`${from.lat},${from.lng}`,
+      destinations:`${to.lat},${to.lng}`,
+      mode,
+      key:apiKey
+    });
+    const url = `https://maps.googleapis.com/maps/api/distancematrix/json?${params.toString()}`;
+    const res = await fetch(url);
+    if(!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    if(data.status !== "OK"){
+      throw new Error(data.error_message || data.status || "Respuesta no válida");
+    }
+    const element = data.rows?.[0]?.elements?.[0];
+    if(!element || element.status !== "OK"){
+      throw new Error(element?.status || "Sin datos");
+    }
+    return {
+      distanceKm: element.distance?.value!=null ? element.distance.value / 1000 : null,
+      durationMin: element.duration?.value!=null ? element.duration.value / 60 : null
+    };
+  };
+
+  const updateSegmentsWithGoogle = async (segments, apiKey)=>{
+    const warnings=[];
+    let updated=0;
+    for(const seg of segments){
+      let driving=null;
+      let walking=null;
+      try{
+        driving = await fetchDistanceMatrix(seg.from, seg.to, "driving", apiKey);
+      }catch(err){
+        warnings.push(`Vehículo ${seg.from.nombre||seg.from.id} → ${seg.to.nombre||seg.to.id}: ${err.message}`);
+      }
+      try{
+        walking = await fetchDistanceMatrix(seg.from, seg.to, "walking", apiKey);
+      }catch(err){
+        warnings.push(`Caminando ${seg.from.nombre||seg.from.id} → ${seg.to.nombre||seg.to.id}: ${err.message}`);
+      }
+      const distanceSource = driving?.distanceKm ?? walking?.distanceKm;
+      if(Number.isFinite(distanceSource)){
+        seg.distanceKm = distanceSource;
+      }
+      if(driving?.durationMin != null){
+        seg.durationDriveMin = driving.durationMin;
+      }
+      if(walking?.durationMin != null){
+        seg.durationWalkMin = walking.durationMin;
+      }
+      updateSegmentEstimates(seg);
+      if(driving || walking){
+        seg.provider = "google";
+        seg.providerNote = `Actualizado con Google Maps (${new Date().toLocaleString()})`;
+        updated++;
+      }
+    }
+    return { updated, warnings };
+  };
+
+  const setupCatalogMap = (container, locations, segments)=>{
+    if(container._cleanup){
+      try{ container._cleanup(); }catch(err){}
+    }
+    container.innerHTML="";
+    if(!locations.length){
+      container.appendChild(el("div","mini","Añade localizaciones con coordenadas para ver el mapa."));
+      return { refresh:()=>{} };
+    }
+
+    const mapArea = el("div","loc-map-area");
+    const canvas = document.createElement("canvas"); canvas.className="loc-map-canvas";
+    const overlay = el("div","loc-map-overlay");
+    mapArea.appendChild(canvas);
+    mapArea.appendChild(overlay);
+    container.appendChild(mapArea);
+
+    const view={ center:{ lat:DEFAULT_MAP_VIEW.lat, lng:DEFAULT_MAP_VIEW.lng }, zoom:DEFAULT_MAP_VIEW.zoom, width:mapArea.clientWidth||760, height:mapArea.clientHeight||420 };
+    const init = computeInitialView(locations, view.width, view.height);
+    view.center = clampLatLng(init.center.lat, init.center.lng);
+    view.zoom = init.zoom;
+
+    const ctx = canvas.getContext("2d");
+    const tileCache = new Map();
+
+    const locationPins = locations.map((loc, idx)=>{
+      const pin=el("div","loc-map-location");
+      pin.appendChild(el("span","loc-map-dot"));
+      pin.appendChild(el("span","loc-map-label", loc.nombre || loc.id || `Punto ${idx+1}`));
+      overlay.appendChild(pin);
+      return { loc, el:pin };
+    });
+
+    const segmentLabels = segments.map((seg)=>{
+      const label = el("div","loc-map-segment","");
+      overlay.appendChild(label);
+      return { seg, el:label };
+    });
+
+    const resize = ()=>{
+      view.width = mapArea.clientWidth || 760;
+      view.height = mapArea.clientHeight || 420;
+      const dpr = window.devicePixelRatio || 1;
+      canvas.width = Math.round(view.width * dpr);
+      canvas.height = Math.round(view.height * dpr);
+      canvas.style.width = `${view.width}px`;
+      canvas.style.height = `${view.height}px`;
+      ctx.setTransform(dpr,0,0,dpr,0,0);
+      render();
+    };
+
+    const getTile = (z,x,y)=>{
+      const key = `${z}/${x}/${y}`;
+      const cached = tileCache.get(key);
+      if(cached){
+        if(cached.ready) return cached.img;
+        return null;
+      }
+      const url = `https://tile.openstreetmap.org/${z}/${x}/${y}.png`;
+      const img = new Image();
+      const entry={ img, ready:false };
+      tileCache.set(key, entry);
+      img.crossOrigin="anonymous";
+      img.onload=()=>{ entry.ready=true; render(); };
+      img.onerror=()=>{ tileCache.delete(key); };
+      img.src=url;
+      return null;
+    };
+
+    const drawTiles = ()=>{
+      ctx.fillStyle="#0b1220";
+      ctx.fillRect(0,0,view.width,view.height);
+      const zoom=view.zoom;
+      const centerPx=latLngToPixel(view.center.lat, view.center.lng, zoom);
+      const topLeftX=centerPx.x - view.width/2;
+      const topLeftY=centerPx.y - view.height/2;
+      const startX=Math.floor(topLeftX / TILE_SIZE);
+      const endX=Math.floor((topLeftX + view.width) / TILE_SIZE);
+      const startY=Math.floor(topLeftY / TILE_SIZE);
+      const endY=Math.floor((topLeftY + view.height) / TILE_SIZE);
+      const tileCount = 1 << zoom;
+      for(let tileX=startX; tileX<=endX; tileX++){
+        for(let tileY=startY; tileY<=endY; tileY++){
+          if(tileY < 0 || tileY >= tileCount) continue;
+          let normX = tileX % tileCount;
+          if(normX < 0) normX += tileCount;
+          const img = getTile(zoom, normX, tileY);
+          const dx = Math.round(tileX * TILE_SIZE - topLeftX);
+          const dy = Math.round(tileY * TILE_SIZE - topLeftY);
+          if(img && img.complete){
+            ctx.drawImage(img, dx, dy, TILE_SIZE, TILE_SIZE);
+          }
+        }
+      }
+    };
+
+    const drawRoutes = ()=>{
+      if(!segments.length) return;
+      ctx.save();
+      ctx.strokeStyle = "rgba(56,189,248,0.85)";
+      ctx.lineWidth = 3;
+      ctx.lineCap = "round";
+      ctx.beginPath();
+      segments.forEach(seg=>{
+        const a = projectPoint(seg.from.lat, seg.from.lng, view);
+        const b = projectPoint(seg.to.lat, seg.to.lng, view);
+        ctx.moveTo(a.x, a.y);
+        ctx.lineTo(b.x, b.y);
+      });
+      ctx.stroke();
+      ctx.restore();
+    };
+
+    const drawPoints = ()=>{
+      ctx.save();
+      ctx.fillStyle="rgba(226,232,240,0.9)";
+      locations.forEach(loc=>{
+        const p = projectPoint(loc.lat, loc.lng, view);
+        ctx.beginPath();
+        ctx.arc(p.x, p.y, 4, 0, Math.PI*2);
+        ctx.fill();
+      });
+      ctx.restore();
+    };
+
+    const updateOverlay = ()=>{
+      locationPins.forEach(pin=>{
+        const pos = projectPoint(pin.loc.lat, pin.loc.lng, view);
+        if(pos.x < -100 || pos.x > view.width+100 || pos.y < -100 || pos.y > view.height+100){
+          pin.el.style.display="none";
+        }else{
+          pin.el.style.display="";
+          pin.el.style.left = `${pos.x}px`;
+          pin.el.style.top = `${pos.y}px`;
+        }
+      });
+      segmentLabels.forEach(item=>{
+        const seg = item.seg;
+        const mid = { lat:(seg.from.lat + seg.to.lat)/2, lng:(seg.from.lng + seg.to.lng)/2 };
+        const pos = projectPoint(mid.lat, mid.lng, view);
+        const text = `${formatDistance(seg.distanceKm)}\nVehículo: ${formatDuration(seg.durationDriveMin)}\nCaminando: ${formatDuration(seg.durationWalkMin)}`;
+        item.el.textContent = text;
+        if(pos.x < -120 || pos.x > view.width+120 || pos.y < -120 || pos.y > view.height+120){
+          item.el.style.display="none";
+        }else{
+          item.el.style.display="";
+          item.el.style.left = `${pos.x}px`;
+          item.el.style.top = `${pos.y}px`;
+        }
+      });
+    };
+
+    const render = ()=>{
+      drawTiles();
+      drawRoutes();
+      drawPoints();
+      updateOverlay();
+    };
+
+    const startDrag = { active:false, pointerId:null, origin:null };
+
+    mapArea.addEventListener("pointerdown", (ev)=>{
+      startDrag.active=true;
+      startDrag.pointerId=ev.pointerId;
+      startDrag.origin={ x:ev.clientX, y:ev.clientY, center:{...view.center} };
+      mapArea.setPointerCapture(ev.pointerId);
+      mapArea.classList.add("panning");
+    });
+    mapArea.addEventListener("pointermove", (ev)=>{
+      if(!startDrag.active || startDrag.pointerId!==ev.pointerId) return;
+      const dx = ev.clientX - startDrag.origin.x;
+      const dy = ev.clientY - startDrag.origin.y;
+      const centerPx = latLngToPixel(startDrag.origin.center.lat, startDrag.origin.center.lng, view.zoom);
+      const newPx = { x: centerPx.x - dx, y: centerPx.y - dy };
+      const raw = pixelToLatLng(newPx.x, newPx.y, view.zoom);
+      view.center = clampLatLng(raw.lat, raw.lng);
+      render();
+    });
+    const endDrag = (ev)=>{
+      if(startDrag.active && (!ev || startDrag.pointerId===ev.pointerId)){
+        startDrag.active=false;
+        mapArea.classList.remove("panning");
+        if(ev) mapArea.releasePointerCapture(ev.pointerId);
+      }
+    };
+    mapArea.addEventListener("pointerup", endDrag);
+    mapArea.addEventListener("pointercancel", endDrag);
+    mapArea.addEventListener("pointerleave", (ev)=>{ if(startDrag.active) endDrag(ev); });
+
+    mapArea.addEventListener("wheel", (ev)=>{
+      ev.preventDefault();
+      const delta = Math.sign(ev.deltaY);
+      const newZoom = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, view.zoom - delta));
+      if(newZoom === view.zoom) return;
+      const rect = mapArea.getBoundingClientRect();
+      const point = { x: ev.clientX - rect.left, y: ev.clientY - rect.top };
+      const before = latLngToPixel(view.center.lat, view.center.lng, view.zoom);
+      const offset = { x: before.x + (point.x - view.width/2), y: before.y + (point.y - view.height/2) };
+      const focusLatLng = pixelToLatLng(offset.x, offset.y, view.zoom);
+      view.zoom = newZoom;
+      const focusPx = latLngToPixel(focusLatLng.lat, focusLatLng.lng, newZoom);
+      const newCenterPx = { x: focusPx.x - (point.x - view.width/2), y: focusPx.y - (point.y - view.height/2) };
+      const newCenter = pixelToLatLng(newCenterPx.x, newCenterPx.y, newZoom);
+      view.center = clampLatLng(newCenter.lat, newCenter.lng);
+      render();
+    }, { passive:false });
+
+    const onResize = ()=>{ resize(); };
+    window.addEventListener("resize", onResize);
+
+    const cleanup = ()=>{
+      window.removeEventListener("resize", onResize);
+      mapArea.classList.remove("panning");
+    };
+    container._cleanup = cleanup;
+
+    resize();
+
+    return { refresh: render };
+  };
+
+  const buildDistancePanel = (segments, mapController)=>{
+    const wrapper = el("div","loc-distance-panel");
+    const controls = el("div","loc-distance-controls");
+    const keyInput = el("input","input loc-distance-key");
+    keyInput.type = "text";
+    keyInput.placeholder = "API key de Google Maps";
+    keyInput.value = loadGoogleApiKey();
+    const saveBtn = el("button","btn small","Guardar API key");
+    const refreshBtn = el("button","btn small","Actualizar con Google Maps");
+    const status = el("div","mini","Las distancias se calculan automáticamente con estimaciones básicas.");
+
+    controls.appendChild(keyInput);
+    controls.appendChild(saveBtn);
+    controls.appendChild(refreshBtn);
+
+    const tableHolder = el("div","loc-distance-table-holder");
+
+    const renderTable = ()=>{
+      tableHolder.innerHTML="";
+      if(!segments.length){
+        tableHolder.appendChild(el("div","mini","Añade al menos dos localizaciones para calcular distancias."));
+        return;
+      }
+      const tbl = el("table","loc-distance-table");
+      const thead = el("thead");
+      const thr = el("tr");
+      ["Desde","Hasta","Distancia","En vehículo","Caminando","Fuente"].forEach(label=>{
+        thr.appendChild(el("th",null,label));
+      });
+      thead.appendChild(thr);
+      tbl.appendChild(thead);
+      const tbody = el("tbody");
+      segments.forEach(seg=>{
+        const tr = el("tr");
+        tr.appendChild(el("td",null,seg.from.nombre || seg.from.id || "-"));
+        tr.appendChild(el("td",null,seg.to.nombre || seg.to.id || "-"));
+        tr.appendChild(el("td",null,formatDistance(seg.distanceKm)));
+        tr.appendChild(el("td",null,formatDuration(seg.durationDriveMin)));
+        tr.appendChild(el("td",null,formatDuration(seg.durationWalkMin)));
+        tr.appendChild(el("td",null, seg.provider === "google" ? "Google Maps" : "Estimación" ));
+        if(seg.providerNote){
+          tr.title = seg.providerNote;
+        }
+        tbody.appendChild(tr);
+      });
+      tbl.appendChild(tbody);
+      tableHolder.appendChild(tbl);
+    };
+
+    renderTable();
+
+    saveBtn.onclick=()=>{
+      const key = keyInput.value || "";
+      const saved = persistGoogleApiKey(key);
+      status.textContent = saved ? "API key guardada en el proyecto actual." : "API key eliminada.";
+    };
+
+    refreshBtn.onclick=async()=>{
+      const key = (keyInput.value || "").trim();
+      if(!key){
+        status.textContent = "Introduce una API key de Google Maps para actualizar las distancias.";
+        keyInput.focus();
+        return;
+      }
+      if(!segments.length){
+        status.textContent = "Añade al menos dos localizaciones antes de consultar Google Maps.";
+        return;
+      }
+      persistGoogleApiKey(key);
+      refreshBtn.disabled = true;
+      saveBtn.disabled = true;
+      status.textContent = "Consultando Google Maps...";
+      try{
+        const { updated, warnings } = await updateSegmentsWithGoogle(segments, key);
+        if(updated){
+          status.textContent = warnings.length
+            ? `Distancias actualizadas. Algunas advertencias: ${warnings[0]}`
+            : "Distancias actualizadas con Google Maps.";
+        }else{
+          status.textContent = warnings[0] || "No se pudieron actualizar las distancias con Google Maps.";
+        }
+      }catch(err){
+        status.textContent = err.message || "No se pudieron obtener distancias de Google Maps.";
+      }finally{
+        refreshBtn.disabled = false;
+        saveBtn.disabled = false;
+        segments.forEach(updateSegmentEstimates);
+        renderTable();
+        if(mapController && typeof mapController.refresh === "function") mapController.refresh();
+      }
+    };
+
+    wrapper.appendChild(controls);
+    wrapper.appendChild(tableHolder);
+    wrapper.appendChild(status);
+    return wrapper;
+  };
   function emitChanged(){ document.dispatchEvent(new Event("catalogs-changed")); touch(); }
 
   function lockMark(tr, locked){ if(!locked) return; tr.setAttribute("data-locked","true"); tr.querySelectorAll("button,input,select").forEach(n=>{ if(n.tagName==="BUTTON" && /eliminar/i.test(n.textContent||"")) n.disabled=true; else if(n.tagName!=="BUTTON") n.disabled=true; }); }
@@ -1266,6 +1821,33 @@
       tr.appendChild(n); tr.appendChild(ll); tr.appendChild(del); tb.appendChild(tr);
     });
     cont.appendChild(tbl);
+
+    const validLocations = (state.locations||[])
+      .map(l=>{
+        const lat = toNumber(l.lat);
+        const lng = toNumber(l.lng);
+        if(!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+        return { ...l, lat, lng };
+      })
+      .filter(Boolean);
+
+    const infoSection = el("div","loc-map-section");
+    infoSection.appendChild(el("h4",null,"Mapa y distancias"));
+
+    const invalidCount = (state.locations?.length || 0) - validLocations.length;
+    if(invalidCount>0){
+      infoSection.appendChild(el("div","mini warn-text",`${invalidCount} localización${invalidCount===1?"":"es"} no tienen coordenadas válidas.`));
+    }
+
+    const mapContainer = el("div","loc-map-container");
+    infoSection.appendChild(mapContainer);
+
+    const segments = buildSegments(validLocations);
+    segments.forEach(updateSegmentEstimates);
+    const mapController = setupCatalogMap(mapContainer, validLocations, segments);
+    infoSection.appendChild(buildDistancePanel(segments, mapController));
+
+    cont.appendChild(infoSection);
   };
 
   window.openCatTask = (cont)=>{

--- a/event-planer-main/assets/app.css
+++ b/event-planer-main/assets/app.css
@@ -638,6 +638,25 @@ table.matlist td.act{width:120px}
   height:12px;
   border-radius:50%;
 }
+.loc-map-section{margin-top:1.5rem;display:flex;flex-direction:column;gap:1rem}
+.loc-map-container{width:100%}
+.loc-map-area{position:relative;min-height:360px;border-radius:.75rem;overflow:hidden;box-shadow:0 0 0 1px rgba(148,163,184,.18);background:#0b1220}
+.loc-map-area.panning .loc-map-canvas{cursor:grabbing}
+.loc-map-canvas{display:block;width:100%;height:100%;cursor:grab}
+.loc-map-overlay{position:absolute;inset:0;pointer-events:none;font-size:.85rem;color:#f8fafc}
+.loc-map-location{position:absolute;transform:translate(-50%,-50%);display:flex;flex-direction:column;align-items:center;gap:.25rem;text-shadow:0 1px 2px rgba(15,23,42,.7)}
+.loc-map-dot{width:10px;height:10px;border-radius:9999px;background:#f97316;border:2px solid rgba(15,23,42,.85)}
+.loc-map-label{background:rgba(15,23,42,.85);padding:.15rem .45rem;border-radius:9999px;white-space:nowrap}
+.loc-map-segment{position:absolute;transform:translate(-50%,-50%);background:rgba(15,23,42,.88);padding:.4rem .6rem;border-radius:.5rem;line-height:1.35;white-space:pre-line;box-shadow:0 8px 20px rgba(15,23,42,.35);max-width:220px;text-align:center}
+.loc-distance-panel{display:flex;flex-direction:column;gap:.75rem;background:rgba(15,23,42,.6);padding:1rem;border-radius:.75rem;box-shadow:0 1px 0 0 rgba(148,163,184,.12) inset}
+.loc-distance-controls{display:flex;flex-wrap:wrap;gap:.5rem;align-items:center}
+.loc-distance-controls .btn.small{min-width:auto}
+.loc-distance-key{flex:1 1 220px}
+.loc-distance-table-holder{overflow-x:auto}
+.loc-distance-table{width:100%;border-collapse:collapse;min-width:520px;background:rgba(15,23,42,.35);border-radius:.5rem;overflow:hidden}
+.loc-distance-table thead th{text-align:left;font-weight:600;padding:.5rem .75rem;background:rgba(15,23,42,.7);border-bottom:1px solid rgba(148,163,184,.2)}
+.loc-distance-table tbody td{padding:.5rem .75rem;border-bottom:1px solid rgba(148,163,184,.15)}
+.loc-distance-table tbody tr:last-child td{border-bottom:none}
 .link-tag{
   background:#0f172a;
   border:1px solid #1f2937;

--- a/event-planer-main/assets/js/catalogs.js
+++ b/event-planer-main/assets/js/catalogs.js
@@ -2,6 +2,561 @@
   "use strict";
   const ACTION_TYPE_TRANSPORT = window.ACTION_TYPE_TRANSPORT || "TRANSPORTE";
   const ACTION_TYPE_NORMAL = window.ACTION_TYPE_NORMAL || "NORMAL";
+  const TILE_SIZE = 256;
+  const MIN_ZOOM = 2;
+  const MAX_ZOOM = 18;
+  const DEFAULT_MAP_VIEW = { lat: 40.4168, lng: -3.7038, zoom: 5 };
+  const WALKING_SPEED_KMPH = 4.5;
+  const DRIVING_SPEED_KMPH = 45;
+  const GOOGLE_KEY_STORAGE = "eventplan.googleMapsKey";
+
+  const toNumber = (value)=>{
+    const str = String(value ?? "").trim().replace(/,/g, ".");
+    if(!str) return NaN;
+    return Number(str);
+  };
+
+  const clampLatLng = (lat, lng)=>{
+    const clampedLat = Math.max(-85.0511, Math.min(85.0511, Number.isFinite(lat) ? lat : 0));
+    let normLng = Number.isFinite(lng) ? lng : 0;
+    normLng = ((normLng + 180) % 360 + 360) % 360 - 180;
+    return { lat: clampedLat, lng: normLng };
+  };
+
+  const latLngToPixel = (lat, lng, zoom)=>{
+    const scale = TILE_SIZE * Math.pow(2, zoom);
+    const sin = Math.sin(lat * Math.PI / 180);
+    const x = (lng + 180) / 360 * scale;
+    const y = (0.5 - Math.log((1 + sin) / (1 - sin)) / (4 * Math.PI)) * scale;
+    return { x, y };
+  };
+
+  const pixelToLatLng = (x, y, zoom)=>{
+    const scale = TILE_SIZE * Math.pow(2, zoom);
+    const lng = x / scale * 360 - 180;
+    const n = Math.PI - 2 * Math.PI * y / scale;
+    const lat = 180 / Math.PI * Math.atan(0.5 * (Math.exp(n) - Math.exp(-n)));
+    return { lat, lng };
+  };
+
+  const computeInitialView = (locations, width, height)=>{
+    if(!locations.length){
+      return { center:{ lat:DEFAULT_MAP_VIEW.lat, lng:DEFAULT_MAP_VIEW.lng }, zoom:DEFAULT_MAP_VIEW.zoom };
+    }
+    const lats = locations.map(l=>l.lat);
+    const lngs = locations.map(l=>l.lng);
+    const minLat = Math.min(...lats);
+    const maxLat = Math.max(...lats);
+    const minLng = Math.min(...lngs);
+    const maxLng = Math.max(...lngs);
+    let zoom = DEFAULT_MAP_VIEW.zoom;
+    for(let z=MAX_ZOOM; z>=MIN_ZOOM; z--){
+      const nw = latLngToPixel(maxLat, minLng, z);
+      const se = latLngToPixel(minLat, maxLng, z);
+      const dx = Math.abs(se.x - nw.x);
+      const dy = Math.abs(se.y - nw.y);
+      if(dx <= width && dy <= height){
+        zoom = z;
+        break;
+      }
+    }
+    return { center:{ lat:(minLat+maxLat)/2, lng:(minLng+maxLng)/2 }, zoom };
+  };
+
+  const projectPoint = (lat, lng, view)=>{
+    const zoom = view.zoom;
+    const centerPx = latLngToPixel(view.center.lat, view.center.lng, zoom);
+    const pointPx = latLngToPixel(lat, lng, zoom);
+    const world = TILE_SIZE * Math.pow(2, zoom);
+    let dx = pointPx.x - centerPx.x;
+    if(dx > world / 2) dx -= world;
+    if(dx < -world / 2) dx += world;
+    const dy = pointPx.y - centerPx.y;
+    return { x: view.width / 2 + dx, y: view.height / 2 + dy };
+  };
+
+  const haversineKm = (a, b)=>{
+    const R = 6371;
+    const toRad = (deg)=>deg * Math.PI / 180;
+    const dLat = toRad(b.lat - a.lat);
+    const dLng = toRad(b.lng - a.lng);
+    const lat1 = toRad(a.lat);
+    const lat2 = toRad(b.lat);
+    const sinLat = Math.sin(dLat / 2);
+    const sinLng = Math.sin(dLng / 2);
+    const h = sinLat * sinLat + sinLng * sinLng * Math.cos(lat1) * Math.cos(lat2);
+    const c = 2 * Math.atan2(Math.sqrt(h), Math.sqrt(Math.max(0, 1 - h)));
+    return R * c;
+  };
+
+  const estimateTimes = (distanceKm)=>{
+    if(!Number.isFinite(distanceKm)){
+      return { drive:null, walk:null };
+    }
+    const drive = (distanceKm / DRIVING_SPEED_KMPH) * 60;
+    const walk = (distanceKm / WALKING_SPEED_KMPH) * 60;
+    return { drive, walk };
+  };
+
+  const ensureGoogleConfig = ()=>{
+    state.integrations = state.integrations || {};
+    state.integrations.googleMaps = state.integrations.googleMaps || { apiKey:"" };
+    return state.integrations.googleMaps;
+  };
+
+  const loadGoogleApiKey = ()=>{
+    const cfg = ensureGoogleConfig();
+    if(cfg.apiKey) return cfg.apiKey;
+    try{
+      return localStorage.getItem(GOOGLE_KEY_STORAGE) || "";
+    }catch(err){
+      return "";
+    }
+  };
+
+  const persistGoogleApiKey = (key)=>{
+    const cfg = ensureGoogleConfig();
+    const trimmed = key.trim();
+    if(cfg.apiKey !== trimmed){
+      cfg.apiKey = trimmed;
+      touch();
+    }
+    try{
+      if(trimmed){
+        localStorage.setItem(GOOGLE_KEY_STORAGE, trimmed);
+      }else{
+        localStorage.removeItem(GOOGLE_KEY_STORAGE);
+      }
+    }catch(err){
+      // Ignore storage errors (e.g. private mode)
+    }
+    return trimmed;
+  };
+
+  const formatDistance = (km)=>{
+    if(!Number.isFinite(km)) return "-";
+    if(km >= 100) return `${km.toFixed(0)} km`;
+    if(km >= 10) return `${km.toFixed(1)} km`;
+    return `${km.toFixed(2)} km`;
+  };
+
+  const formatDuration = (mins)=>{
+    if(!Number.isFinite(mins)) return "-";
+    const total = Math.max(0, Math.round(mins));
+    const h = Math.floor(total / 60);
+    const m = total % 60;
+    if(h && m) return `${h}h ${m}m`;
+    if(h) return `${h}h`;
+    return `${m}m`;
+  };
+
+  const buildSegments = (locations)=>{
+    const segments=[];
+    for(let i=0; i<locations.length-1; i++){
+      const from = locations[i];
+      const to = locations[i+1];
+      const distanceKm = haversineKm(from, to);
+      const { drive, walk } = estimateTimes(distanceKm);
+      segments.push({
+        id:`${from.id||i}_${to.id||i+1}`,
+        from,
+        to,
+        distanceKm,
+        durationDriveMin: drive,
+        durationWalkMin: walk,
+        provider:"estimate",
+        providerNote:"Estimación basada en distancia geodésica"
+      });
+    }
+    return segments;
+  };
+
+  const updateSegmentEstimates = (seg)=>{
+    if(!Number.isFinite(seg.distanceKm)) return;
+    const { drive, walk } = estimateTimes(seg.distanceKm);
+    if(!Number.isFinite(seg.durationDriveMin)) seg.durationDriveMin = drive;
+    if(!Number.isFinite(seg.durationWalkMin)) seg.durationWalkMin = walk;
+  };
+
+  const fetchDistanceMatrix = async (from, to, mode, apiKey)=>{
+    const params = new URLSearchParams({
+      units:"metric",
+      origins:`${from.lat},${from.lng}`,
+      destinations:`${to.lat},${to.lng}`,
+      mode,
+      key:apiKey
+    });
+    const url = `https://maps.googleapis.com/maps/api/distancematrix/json?${params.toString()}`;
+    const res = await fetch(url);
+    if(!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    if(data.status !== "OK"){
+      throw new Error(data.error_message || data.status || "Respuesta no válida");
+    }
+    const element = data.rows?.[0]?.elements?.[0];
+    if(!element || element.status !== "OK"){
+      throw new Error(element?.status || "Sin datos");
+    }
+    return {
+      distanceKm: element.distance?.value!=null ? element.distance.value / 1000 : null,
+      durationMin: element.duration?.value!=null ? element.duration.value / 60 : null
+    };
+  };
+
+  const updateSegmentsWithGoogle = async (segments, apiKey)=>{
+    const warnings=[];
+    let updated=0;
+    for(const seg of segments){
+      let driving=null;
+      let walking=null;
+      try{
+        driving = await fetchDistanceMatrix(seg.from, seg.to, "driving", apiKey);
+      }catch(err){
+        warnings.push(`Vehículo ${seg.from.nombre||seg.from.id} → ${seg.to.nombre||seg.to.id}: ${err.message}`);
+      }
+      try{
+        walking = await fetchDistanceMatrix(seg.from, seg.to, "walking", apiKey);
+      }catch(err){
+        warnings.push(`Caminando ${seg.from.nombre||seg.from.id} → ${seg.to.nombre||seg.to.id}: ${err.message}`);
+      }
+      const distanceSource = driving?.distanceKm ?? walking?.distanceKm;
+      if(Number.isFinite(distanceSource)){
+        seg.distanceKm = distanceSource;
+      }
+      if(driving?.durationMin != null){
+        seg.durationDriveMin = driving.durationMin;
+      }
+      if(walking?.durationMin != null){
+        seg.durationWalkMin = walking.durationMin;
+      }
+      updateSegmentEstimates(seg);
+      if(driving || walking){
+        seg.provider = "google";
+        seg.providerNote = `Actualizado con Google Maps (${new Date().toLocaleString()})`;
+        updated++;
+      }
+    }
+    return { updated, warnings };
+  };
+
+  const setupCatalogMap = (container, locations, segments)=>{
+    if(container._cleanup){
+      try{ container._cleanup(); }catch(err){}
+    }
+    container.innerHTML="";
+    if(!locations.length){
+      container.appendChild(el("div","mini","Añade localizaciones con coordenadas para ver el mapa."));
+      return { refresh:()=>{} };
+    }
+
+    const mapArea = el("div","loc-map-area");
+    const canvas = document.createElement("canvas"); canvas.className="loc-map-canvas";
+    const overlay = el("div","loc-map-overlay");
+    mapArea.appendChild(canvas);
+    mapArea.appendChild(overlay);
+    container.appendChild(mapArea);
+
+    const view={ center:{ lat:DEFAULT_MAP_VIEW.lat, lng:DEFAULT_MAP_VIEW.lng }, zoom:DEFAULT_MAP_VIEW.zoom, width:mapArea.clientWidth||760, height:mapArea.clientHeight||420 };
+    const init = computeInitialView(locations, view.width, view.height);
+    view.center = clampLatLng(init.center.lat, init.center.lng);
+    view.zoom = init.zoom;
+
+    const ctx = canvas.getContext("2d");
+    const tileCache = new Map();
+
+    const locationPins = locations.map((loc, idx)=>{
+      const pin=el("div","loc-map-location");
+      pin.appendChild(el("span","loc-map-dot"));
+      pin.appendChild(el("span","loc-map-label", loc.nombre || loc.id || `Punto ${idx+1}`));
+      overlay.appendChild(pin);
+      return { loc, el:pin };
+    });
+
+    const segmentLabels = segments.map((seg)=>{
+      const label = el("div","loc-map-segment","");
+      overlay.appendChild(label);
+      return { seg, el:label };
+    });
+
+    const resize = ()=>{
+      view.width = mapArea.clientWidth || 760;
+      view.height = mapArea.clientHeight || 420;
+      const dpr = window.devicePixelRatio || 1;
+      canvas.width = Math.round(view.width * dpr);
+      canvas.height = Math.round(view.height * dpr);
+      canvas.style.width = `${view.width}px`;
+      canvas.style.height = `${view.height}px`;
+      ctx.setTransform(dpr,0,0,dpr,0,0);
+      render();
+    };
+
+    const getTile = (z,x,y)=>{
+      const key = `${z}/${x}/${y}`;
+      const cached = tileCache.get(key);
+      if(cached){
+        if(cached.ready) return cached.img;
+        return null;
+      }
+      const url = `https://tile.openstreetmap.org/${z}/${x}/${y}.png`;
+      const img = new Image();
+      const entry={ img, ready:false };
+      tileCache.set(key, entry);
+      img.crossOrigin="anonymous";
+      img.onload=()=>{ entry.ready=true; render(); };
+      img.onerror=()=>{ tileCache.delete(key); };
+      img.src=url;
+      return null;
+    };
+
+    const drawTiles = ()=>{
+      ctx.fillStyle="#0b1220";
+      ctx.fillRect(0,0,view.width,view.height);
+      const zoom=view.zoom;
+      const centerPx=latLngToPixel(view.center.lat, view.center.lng, zoom);
+      const topLeftX=centerPx.x - view.width/2;
+      const topLeftY=centerPx.y - view.height/2;
+      const startX=Math.floor(topLeftX / TILE_SIZE);
+      const endX=Math.floor((topLeftX + view.width) / TILE_SIZE);
+      const startY=Math.floor(topLeftY / TILE_SIZE);
+      const endY=Math.floor((topLeftY + view.height) / TILE_SIZE);
+      const tileCount = 1 << zoom;
+      for(let tileX=startX; tileX<=endX; tileX++){
+        for(let tileY=startY; tileY<=endY; tileY++){
+          if(tileY < 0 || tileY >= tileCount) continue;
+          let normX = tileX % tileCount;
+          if(normX < 0) normX += tileCount;
+          const img = getTile(zoom, normX, tileY);
+          const dx = Math.round(tileX * TILE_SIZE - topLeftX);
+          const dy = Math.round(tileY * TILE_SIZE - topLeftY);
+          if(img && img.complete){
+            ctx.drawImage(img, dx, dy, TILE_SIZE, TILE_SIZE);
+          }
+        }
+      }
+    };
+
+    const drawRoutes = ()=>{
+      if(!segments.length) return;
+      ctx.save();
+      ctx.strokeStyle = "rgba(56,189,248,0.85)";
+      ctx.lineWidth = 3;
+      ctx.lineCap = "round";
+      ctx.beginPath();
+      segments.forEach(seg=>{
+        const a = projectPoint(seg.from.lat, seg.from.lng, view);
+        const b = projectPoint(seg.to.lat, seg.to.lng, view);
+        ctx.moveTo(a.x, a.y);
+        ctx.lineTo(b.x, b.y);
+      });
+      ctx.stroke();
+      ctx.restore();
+    };
+
+    const drawPoints = ()=>{
+      ctx.save();
+      ctx.fillStyle="rgba(226,232,240,0.9)";
+      locations.forEach(loc=>{
+        const p = projectPoint(loc.lat, loc.lng, view);
+        ctx.beginPath();
+        ctx.arc(p.x, p.y, 4, 0, Math.PI*2);
+        ctx.fill();
+      });
+      ctx.restore();
+    };
+
+    const updateOverlay = ()=>{
+      locationPins.forEach(pin=>{
+        const pos = projectPoint(pin.loc.lat, pin.loc.lng, view);
+        if(pos.x < -100 || pos.x > view.width+100 || pos.y < -100 || pos.y > view.height+100){
+          pin.el.style.display="none";
+        }else{
+          pin.el.style.display="";
+          pin.el.style.left = `${pos.x}px`;
+          pin.el.style.top = `${pos.y}px`;
+        }
+      });
+      segmentLabels.forEach(item=>{
+        const seg = item.seg;
+        const mid = { lat:(seg.from.lat + seg.to.lat)/2, lng:(seg.from.lng + seg.to.lng)/2 };
+        const pos = projectPoint(mid.lat, mid.lng, view);
+        const text = `${formatDistance(seg.distanceKm)}\nVehículo: ${formatDuration(seg.durationDriveMin)}\nCaminando: ${formatDuration(seg.durationWalkMin)}`;
+        item.el.textContent = text;
+        if(pos.x < -120 || pos.x > view.width+120 || pos.y < -120 || pos.y > view.height+120){
+          item.el.style.display="none";
+        }else{
+          item.el.style.display="";
+          item.el.style.left = `${pos.x}px`;
+          item.el.style.top = `${pos.y}px`;
+        }
+      });
+    };
+
+    const render = ()=>{
+      drawTiles();
+      drawRoutes();
+      drawPoints();
+      updateOverlay();
+    };
+
+    const startDrag = { active:false, pointerId:null, origin:null };
+
+    mapArea.addEventListener("pointerdown", (ev)=>{
+      startDrag.active=true;
+      startDrag.pointerId=ev.pointerId;
+      startDrag.origin={ x:ev.clientX, y:ev.clientY, center:{...view.center} };
+      mapArea.setPointerCapture(ev.pointerId);
+      mapArea.classList.add("panning");
+    });
+    mapArea.addEventListener("pointermove", (ev)=>{
+      if(!startDrag.active || startDrag.pointerId!==ev.pointerId) return;
+      const dx = ev.clientX - startDrag.origin.x;
+      const dy = ev.clientY - startDrag.origin.y;
+      const centerPx = latLngToPixel(startDrag.origin.center.lat, startDrag.origin.center.lng, view.zoom);
+      const newPx = { x: centerPx.x - dx, y: centerPx.y - dy };
+      const raw = pixelToLatLng(newPx.x, newPx.y, view.zoom);
+      view.center = clampLatLng(raw.lat, raw.lng);
+      render();
+    });
+    const endDrag = (ev)=>{
+      if(startDrag.active && (!ev || startDrag.pointerId===ev.pointerId)){
+        startDrag.active=false;
+        mapArea.classList.remove("panning");
+        if(ev) mapArea.releasePointerCapture(ev.pointerId);
+      }
+    };
+    mapArea.addEventListener("pointerup", endDrag);
+    mapArea.addEventListener("pointercancel", endDrag);
+    mapArea.addEventListener("pointerleave", (ev)=>{ if(startDrag.active) endDrag(ev); });
+
+    mapArea.addEventListener("wheel", (ev)=>{
+      ev.preventDefault();
+      const delta = Math.sign(ev.deltaY);
+      const newZoom = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, view.zoom - delta));
+      if(newZoom === view.zoom) return;
+      const rect = mapArea.getBoundingClientRect();
+      const point = { x: ev.clientX - rect.left, y: ev.clientY - rect.top };
+      const before = latLngToPixel(view.center.lat, view.center.lng, view.zoom);
+      const offset = { x: before.x + (point.x - view.width/2), y: before.y + (point.y - view.height/2) };
+      const focusLatLng = pixelToLatLng(offset.x, offset.y, view.zoom);
+      view.zoom = newZoom;
+      const focusPx = latLngToPixel(focusLatLng.lat, focusLatLng.lng, newZoom);
+      const newCenterPx = { x: focusPx.x - (point.x - view.width/2), y: focusPx.y - (point.y - view.height/2) };
+      const newCenter = pixelToLatLng(newCenterPx.x, newCenterPx.y, newZoom);
+      view.center = clampLatLng(newCenter.lat, newCenter.lng);
+      render();
+    }, { passive:false });
+
+    const onResize = ()=>{ resize(); };
+    window.addEventListener("resize", onResize);
+
+    const cleanup = ()=>{
+      window.removeEventListener("resize", onResize);
+      mapArea.classList.remove("panning");
+    };
+    container._cleanup = cleanup;
+
+    resize();
+
+    return { refresh: render };
+  };
+
+  const buildDistancePanel = (segments, mapController)=>{
+    const wrapper = el("div","loc-distance-panel");
+    const controls = el("div","loc-distance-controls");
+    const keyInput = el("input","input loc-distance-key");
+    keyInput.type = "text";
+    keyInput.placeholder = "API key de Google Maps";
+    keyInput.value = loadGoogleApiKey();
+    const saveBtn = el("button","btn small","Guardar API key");
+    const refreshBtn = el("button","btn small","Actualizar con Google Maps");
+    const status = el("div","mini","Las distancias se calculan automáticamente con estimaciones básicas.");
+
+    controls.appendChild(keyInput);
+    controls.appendChild(saveBtn);
+    controls.appendChild(refreshBtn);
+
+    const tableHolder = el("div","loc-distance-table-holder");
+
+    const renderTable = ()=>{
+      tableHolder.innerHTML="";
+      if(!segments.length){
+        tableHolder.appendChild(el("div","mini","Añade al menos dos localizaciones para calcular distancias."));
+        return;
+      }
+      const tbl = el("table","loc-distance-table");
+      const thead = el("thead");
+      const thr = el("tr");
+      ["Desde","Hasta","Distancia","En vehículo","Caminando","Fuente"].forEach(label=>{
+        thr.appendChild(el("th",null,label));
+      });
+      thead.appendChild(thr);
+      tbl.appendChild(thead);
+      const tbody = el("tbody");
+      segments.forEach(seg=>{
+        const tr = el("tr");
+        tr.appendChild(el("td",null,seg.from.nombre || seg.from.id || "-"));
+        tr.appendChild(el("td",null,seg.to.nombre || seg.to.id || "-"));
+        tr.appendChild(el("td",null,formatDistance(seg.distanceKm)));
+        tr.appendChild(el("td",null,formatDuration(seg.durationDriveMin)));
+        tr.appendChild(el("td",null,formatDuration(seg.durationWalkMin)));
+        tr.appendChild(el("td",null, seg.provider === "google" ? "Google Maps" : "Estimación" ));
+        if(seg.providerNote){
+          tr.title = seg.providerNote;
+        }
+        tbody.appendChild(tr);
+      });
+      tbl.appendChild(tbody);
+      tableHolder.appendChild(tbl);
+    };
+
+    renderTable();
+
+    saveBtn.onclick=()=>{
+      const key = keyInput.value || "";
+      const saved = persistGoogleApiKey(key);
+      status.textContent = saved ? "API key guardada en el proyecto actual." : "API key eliminada.";
+    };
+
+    refreshBtn.onclick=async()=>{
+      const key = (keyInput.value || "").trim();
+      if(!key){
+        status.textContent = "Introduce una API key de Google Maps para actualizar las distancias.";
+        keyInput.focus();
+        return;
+      }
+      if(!segments.length){
+        status.textContent = "Añade al menos dos localizaciones antes de consultar Google Maps.";
+        return;
+      }
+      persistGoogleApiKey(key);
+      refreshBtn.disabled = true;
+      saveBtn.disabled = true;
+      status.textContent = "Consultando Google Maps...";
+      try{
+        const { updated, warnings } = await updateSegmentsWithGoogle(segments, key);
+        if(updated){
+          status.textContent = warnings.length
+            ? `Distancias actualizadas. Algunas advertencias: ${warnings[0]}`
+            : "Distancias actualizadas con Google Maps.";
+        }else{
+          status.textContent = warnings[0] || "No se pudieron actualizar las distancias con Google Maps.";
+        }
+      }catch(err){
+        status.textContent = err.message || "No se pudieron obtener distancias de Google Maps.";
+      }finally{
+        refreshBtn.disabled = false;
+        saveBtn.disabled = false;
+        segments.forEach(updateSegmentEstimates);
+        renderTable();
+        if(mapController && typeof mapController.refresh === "function") mapController.refresh();
+      }
+    };
+
+    wrapper.appendChild(controls);
+    wrapper.appendChild(tableHolder);
+    wrapper.appendChild(status);
+    return wrapper;
+  };
   function emitChanged(){ document.dispatchEvent(new Event("catalogs-changed")); touch(); }
 
   function lockMark(tr, locked){ if(!locked) return; tr.setAttribute("data-locked","true"); tr.querySelectorAll("button,input,select").forEach(n=>{ if(n.tagName==="BUTTON" && /eliminar/i.test(n.textContent||"")) n.disabled=true; else if(n.tagName!=="BUTTON") n.disabled=true; }); }
@@ -41,6 +596,33 @@
       tr.appendChild(n); tr.appendChild(ll); tr.appendChild(del); tb.appendChild(tr);
     });
     cont.appendChild(tbl);
+
+    const validLocations = (state.locations||[])
+      .map(l=>{
+        const lat = toNumber(l.lat);
+        const lng = toNumber(l.lng);
+        if(!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+        return { ...l, lat, lng };
+      })
+      .filter(Boolean);
+
+    const infoSection = el("div","loc-map-section");
+    infoSection.appendChild(el("h4",null,"Mapa y distancias"));
+
+    const invalidCount = (state.locations?.length || 0) - validLocations.length;
+    if(invalidCount>0){
+      infoSection.appendChild(el("div","mini warn-text",`${invalidCount} localización${invalidCount===1?"":"es"} no tienen coordenadas válidas.`));
+    }
+
+    const mapContainer = el("div","loc-map-container");
+    infoSection.appendChild(mapContainer);
+
+    const segments = buildSegments(validLocations);
+    segments.forEach(updateSegmentEstimates);
+    const mapController = setupCatalogMap(mapContainer, validLocations, segments);
+    infoSection.appendChild(buildDistancePanel(segments, mapController));
+
+    cont.appendChild(infoSection);
   };
 
   window.openCatTask = (cont)=>{

--- a/event-planer-main/assets/js/state.js
+++ b/event-planer-main/assets/js/state.js
@@ -25,6 +25,7 @@
   if(!root.state){
     root.state = {
       project:{ nombre:"Proyecto", fecha:"", tz:"Europe/Madrid", updatedAt:"", view:{ lastTab:"CLIENTE", subGantt:"Gantt", selectedIndex:{} } },
+      integrations:{ googleMaps:{ apiKey:"" } },
       locations:[
         { id:"L_STAGE", nombre:"Escenario principal", lat:"41.3870", lng:"2.1701" },
         { id:"L_STORAGE", nombre:"Almacén central", lat:"41.3865", lng:"2.1698" },


### PR DESCRIPTION
## Summary
- add an interactive map and travel distance summary to the locations catalog
- support optional Google Maps Distance Matrix lookups alongside fallback estimates
- extend styling and default state to persist Google Maps configuration

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68dd5f28e2d8832a827930b93d7ddd13