### PR TITLE
Add map legend enhancements and visibility controls

### DIFF
--- a/event-planer-main/assets/app.css
+++ b/event-planer-main/assets/app.css
@@ -651,6 +651,17 @@ table.matlist td.act{width:120px}
 .loc-map-legend-item{display:flex;align-items:center;gap:.4rem;padding:.35rem .6rem;border-radius:.6rem;background:rgba(15,23,42,.72)}
 .loc-map-legend-swatch{width:12px;height:12px;border-radius:9999px;box-shadow:0 0 0 2px rgba(15,23,42,.65)}
 .loc-map-legend-label{white-space:nowrap}
+.loc-map-legend-meta{font-size:.75rem;color:#cbd5f5;margin-left:.5rem}
+.loc-visibility-panel{margin-top:.5rem;display:flex;flex-direction:column;gap:.6rem;padding:.75rem 1rem;border-radius:.9rem;background:rgba(15,23,42,.55);box-shadow:0 12px 32px rgba(15,23,42,.28);color:#e2e8f0}
+.loc-visibility-panel h4{margin:0;font-size:1rem;font-weight:600;color:#f8fafc}
+.loc-visibility-actions{display:flex;flex-wrap:wrap;gap:.5rem;align-items:center}
+.loc-visibility-actions .btn{font-size:.8rem;padding:.35rem .85rem}
+.loc-visibility-summary{font-size:.8rem;color:#cbd5f5}
+.loc-visibility-list{max-height:200px;overflow:auto;display:flex;flex-direction:column;gap:.35rem;padding-right:.25rem}
+.loc-visibility-item{display:flex;align-items:center;gap:.5rem;background:rgba(15,23,42,.6);padding:.4rem .6rem;border-radius:.65rem}
+.loc-visibility-item input[type=checkbox]{width:16px;height:16px;margin:0}
+.loc-visibility-swatch{width:12px;height:12px;border-radius:9999px;box-shadow:0 0 0 2px rgba(15,23,42,.7)}
+.loc-visibility-item span.label{flex:1}
 .loc-distance-panel{display:flex;flex-direction:column;gap:.75rem;background:rgba(15,23,42,.6);padding:1rem;border-radius:.75rem;box-shadow:0 1px 0 0 rgba(148,163,184,.12) inset}
 .loc-distance-controls{display:flex;flex-wrap:wrap;gap:.5rem;align-items:center}
 .loc-distance-controls .btn.small{min-width:auto}


### PR DESCRIPTION
## Summary
- color-code catalog map routes and legend entries while showing distance information
- add a visibility selector for catalog locations so only chosen points render on the map
- style the new legend metadata and visibility controls for the location catalog view

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dda05c1454832abafdb99f2ea5e4d7