### PR TITLE
Ensure AI-generated schedules are validated and transport-aware

### DIFF
--- a/event-planer-main/assets/new-ui.js
+++ b/event-planer-main/assets/new-ui.js
@@ -4133,6 +4133,7 @@ Si una tarea no cabe en su ventana, falta tiempo de desplazamiento o surge cualq
     const locationList=(state.locations||[]);
     const locationById=new Map(locationList.map(loc=>[String(loc.id), loc]));
     const locationByName=new Map(locationList.map(loc=>[(loc.nombre||loc.id||"").toLowerCase(), loc]));
+    const scheduledTaskIds=new Set();
     const resolveLocationIdFromHint = (hint)=>{
       if(hint==null) return null;
       const text=String(hint).trim();
@@ -4234,7 +4235,10 @@ Si una tarea no cabe en su ventana, falta tiempo de desplazamiento o surge cualq
           if(vehicleId) sessionEntry.vehicleId=vehicleId;
         }
 
-        sessions.push(sessionEntry);
+        const enforced=enforceSessionConstraintsForTask(task, sessionEntry, staffWarnings);
+        if(!enforced) return;
+        scheduledTaskIds.add(task.id);
+        sessions.push(enforced);
       });
 
       sessionsByStaff[staffId]=sessions.sort((a,b)=>{
@@ -4253,6 +4257,39 @@ Si una tarea no cabe en su ventana, falta tiempo de desplazamiento o surge cualq
     state.sessions = state.sessions || {};
     Object.keys(state.sessions).forEach(key=>{
       if(key!=="CLIENTE" && !sessionsByStaff[key]) delete state.sessions[key];
+    });
+
+    Object.entries(sessionsByStaff).forEach(([staffId, list])=>{
+      const warnSet=warningsByStaff[staffId] instanceof Set
+        ? warningsByStaff[staffId]
+        : new Set(warningsByStaff[staffId]||[]);
+      warningsByStaff[staffId]=warnSet;
+      const { sessions:augmented, skippedTaskIds } = insertMissingTransportsForStaff(staffId, list, warnSet);
+      sessionsByStaff[staffId]=augmented;
+      skippedTaskIds.forEach(taskId=> scheduledTaskIds.delete(taskId));
+    });
+
+    validateAndPruneSchedule(sessionsByStaff, warningsByStaff, scheduledTaskIds, taskById);
+
+    tasks.forEach(task=>{
+      if(!task || !task.id) return;
+      if(!taskRequiresPresence(task)) return;
+      if(scheduledTaskIds.has(task.id)) return;
+      const message=`${labelForTask(task)}: no se pudo programar dentro de sus restricciones.`;
+      const assigned=Array.isArray(task.assignedStaffIds)?task.assignedStaffIds.filter(Boolean):[];
+      if(assigned.length){
+        assigned.forEach(id=>{
+          if(!staffById.has(id)){
+            globalWarnings.add(message);
+            return;
+          }
+          const warnSet=warningsByStaff[id] instanceof Set ? warningsByStaff[id] : new Set(warningsByStaff[id]||[]);
+          warnSet.add(message);
+          warningsByStaff[id]=warnSet;
+        });
+        return;
+      }
+      globalWarnings.add(message);
     });
 
     const metricsByStaff={};


### PR DESCRIPTION
## Summary
- enforce per-task window and duration constraints before accepting AI sessions
- inject inferred transport legs, validate dependencies, and surface warnings for unscheduled required tasks

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68df03604cb4832aa7360e7149bde1f3