### PR TITLE
Allow schedules to start without a default 9am constraint

### DIFF
--- a/event-planer-main/assets/app.bundle.js
+++ b/event-planer-main/assets/app.bundle.js
@@ -370,7 +370,7 @@
   function durationOf(s){ return Math.max(5, (parseInt(s.endMin||0,10)||0) - (parseInt(s.startMin||0,10)||0)); }
   function reflow(pid){
     const list=getPersonSessions(pid);
-    let cur = (state.horaInicial?.[pid] ?? 9*60);
+    let cur = (state.horaInicial?.[pid] ?? 0);
     for(let i=0;i<list.length;i++){
       const d = durationOf(list[i]);
       list[i].startMin = cur; list[i].endMin = cur + d; cur = list[i].endMin;
@@ -379,7 +379,7 @@
   window.addAfterIndex = (pid, idx, durMin)=>{
     const list=getPersonSessions(pid); const wasEmpty=!list.length;
     const d=Math.max(5,Math.round((parseInt(durMin||15,10)||15)/5)*5);
-    const start = (idx!=null && idx>=0 && list[idx]) ? list[idx].endMin : (list.length? list[list.length-1].endMin : (state.horaInicial?.[pid]??9*60));
+    const start = (idx!=null && idx>=0 && list[idx]) ? list[idx].endMin : (list.length? list[list.length-1].endMin : (state.horaInicial?.[pid] ?? 0));
     const initialLoc = wasEmpty ? (state.localizacionInicial?.[pid] ?? null) : null;
     const s={ id:"S_"+(++__S_SEQ), startMin:start, endMin:start+d, taskTypeId:null, actionType:ACTION_TYPE_NORMAL, actionName:"", locationId:initialLoc, vehicleId:null, materiales:[], comentario:"", prevId:null, nextId:null, inheritFromId:null };
     list.splice((idx!=null && idx>=0)? idx+1 : list.length, 0, s);
@@ -2355,11 +2355,18 @@
     if(!sessions.length){
       const lbl=el("span","mini","Hora inicio");
       const ti=el("input","input"); ti.type="time";
-      ti.value = toHHMM(state.horaInicial?.[pid] ?? 9*60);
+      ti.value = state.horaInicial?.[pid]!=null ? toHHMM(state.horaInicial[pid]) : "";
       ti.onchange=()=>{
-        state.horaInicial[pid]=toMin(ti.value||"09:00");
+        state.horaInicial = state.horaInicial || {};
+        const raw = (ti.value || "").trim();
+        if(!raw){
+          delete state.horaInicial[pid];
+        }else{
+          state.horaInicial[pid]=toMin(raw);
+        }
         if(sessions.length){
-          rebaseTo(pid,state.horaInicial[pid]);
+          const base = state.horaInicial?.[pid] ?? 0;
+          rebaseTo(pid, base);
         }else{
           touch();
         }

--- a/event-planer-main/assets/app.bundle.js.20250922_170332.bak
+++ b/event-planer-main/assets/app.bundle.js.20250922_170332.bak
@@ -104,7 +104,7 @@
   function durationOf(s){ return Math.max(5, (parseInt(s.endMin||0,10)||0) - (parseInt(s.startMin||0,10)||0)); }
   function reflow(pid){
     const list=getPersonSessions(pid);
-    let cur = (state.horaInicial?.[pid] ?? 9*60);
+    let cur = (state.horaInicial?.[pid] ?? 0);
     for(let i=0;i<list.length;i++){
       const d = durationOf(list[i]);
       list[i].startMin = cur; list[i].endMin = cur + d; cur = list[i].endMin;
@@ -112,7 +112,7 @@
   }
   window.addAfterIndex = (pid, idx, durMin)=>{
     const list=getPersonSessions(pid); const d=Math.max(5,Math.round((parseInt(durMin||15,10)||15)/5)*5);
-    const start = (idx!=null && idx>=0 && list[idx]) ? list[idx].endMin : (list.length? list[list.length-1].endMin : (state.horaInicial?.[pid]??9*60));
+    const start = (idx!=null && idx>=0 && list[idx]) ? list[idx].endMin : (list.length? list[list.length-1].endMin : (state.horaInicial?.[pid] ?? 0));
     const s={ id:"S_"+(++__S_SEQ), startMin:start, endMin:start+d, taskTypeId:null, locationId:null, vehicleId:null, materiales:[], comentario:"", prevId:null, nextId:null, inheritFromId:null };
     list.splice((idx!=null && idx>=0)? idx+1 : list.length, 0, s);
     reflow(pid); recomputeLocations(pid); touch();
@@ -487,8 +487,19 @@
     root.innerHTML="";
     const bar=el("div","toolbar");
     const lbl=el("span","mini","Hora inicio"); const ti=el("input","input"); ti.type="time";
-    ti.value = toHHMM(state.horaInicial?.[pid] ?? 9*60);
-    ti.onchange=()=>{ state.horaInicial[pid]=toMin(ti.value||"09:00"); rebaseTo(pid,state.horaInicial[pid]); renderClient(); };
+    ti.value = state.horaInicial?.[pid]!=null ? toHHMM(state.horaInicial[pid]) : "";
+    ti.onchange=()=>{
+      state.horaInicial = state.horaInicial || {};
+      const raw = (ti.value || "").trim();
+      if(!raw){
+        delete state.horaInicial[pid];
+      }else{
+        state.horaInicial[pid]=toMin(raw);
+      }
+      const base = state.horaInicial?.[pid] ?? 0;
+      rebaseTo(pid, base);
+      renderClient();
+    };
     const add=el("button","btn primary","Crear accion");
     add.onclick=()=>{ const idx=getSelected(pid); addAfterIndex(pid, (idx==null? -1: idx), 15); renderClient(); };
     bar.appendChild(lbl); bar.appendChild(ti); bar.appendChild(add); root.appendChild(bar);

--- a/event-planer-main/assets/js/editor.js
+++ b/event-planer-main/assets/js/editor.js
@@ -239,11 +239,18 @@
     if(!sessions.length){
       const lbl=el("span","mini","Hora inicio");
       const ti=el("input","input"); ti.type="time";
-      ti.value = toHHMM(state.horaInicial?.[pid] ?? 9*60);
+      ti.value = state.horaInicial?.[pid]!=null ? toHHMM(state.horaInicial[pid]) : "";
       ti.onchange=()=>{
-        state.horaInicial[pid]=toMin(ti.value||"09:00");
+        state.horaInicial = state.horaInicial || {};
+        const raw = (ti.value || "").trim();
+        if(!raw){
+          delete state.horaInicial[pid];
+        }else{
+          state.horaInicial[pid]=toMin(raw);
+        }
         if(sessions.length){
-          rebaseTo(pid,state.horaInicial[pid]);
+          const base = state.horaInicial?.[pid] ?? 0;
+          rebaseTo(pid, base);
         }else{
           touch();
         }

--- a/event-planer-main/assets/js/sessions.js
+++ b/event-planer-main/assets/js/sessions.js
@@ -11,7 +11,7 @@
   function durationOf(s){ return Math.max(5, (parseInt(s.endMin||0,10)||0) - (parseInt(s.startMin||0,10)||0)); }
   function reflow(pid){
     const list=getPersonSessions(pid);
-    let cur = (state.horaInicial?.[pid] ?? 9*60);
+    let cur = (state.horaInicial?.[pid] ?? 0);
     for(let i=0;i<list.length;i++){
       const d = durationOf(list[i]);
       list[i].startMin = cur; list[i].endMin = cur + d; cur = list[i].endMin;
@@ -20,7 +20,7 @@
   window.addAfterIndex = (pid, idx, durMin)=>{
     const list=getPersonSessions(pid); const wasEmpty=!list.length;
     const d=Math.max(5,Math.round((parseInt(durMin||15,10)||15)/5)*5);
-    const start = (idx!=null && idx>=0 && list[idx]) ? list[idx].endMin : (list.length? list[list.length-1].endMin : (state.horaInicial?.[pid]??9*60));
+    const start = (idx!=null && idx>=0 && list[idx]) ? list[idx].endMin : (list.length? list[list.length-1].endMin : (state.horaInicial?.[pid] ?? 0));
     const initialLoc = wasEmpty ? (state.localizacionInicial?.[pid] ?? null) : null;
     const s={ id:"S_"+(++__S_SEQ), startMin:start, endMin:start+d, taskTypeId:null, actionType:ACTION_TYPE_NORMAL, actionName:"", locationId:initialLoc, vehicleId:null, materiales:[], comentario:"", prevId:null, nextId:null, inheritFromId:null };
     list.splice((idx!=null && idx>=0)? idx+1 : list.length, 0, s);

--- a/event-planer-main/assets/new-ui.js
+++ b/event-planer-main/assets/new-ui.js
@@ -303,7 +303,7 @@
   const getInitialMinuteFor = (pid)=> parseStoredMinute(state.horaInicial?.[pid]);
   const defaultTimelineStart = ()=>{
     const start=getInitialMinuteFor("CLIENTE");
-    return start!=null ? roundToFive(start) : 9*60;
+    return start!=null ? roundToFive(start) : 0;
   };
   const clampToDay = (mins)=> Math.max(0, Math.min(DAY_MAX_MIN, Number(mins)||0));
   const formatTimeForInput = (mins)=>{
@@ -630,7 +630,7 @@
       materiales: [],
       comentario: "",
       assignedStaffIds: [],
-      startMin: parentId?null:(getInitialMinuteFor("CLIENTE") ?? 9*60),
+      startMin: parentId?null:(getInitialMinuteFor("CLIENTE") ?? 0),
       endMin: null,
       actionType: ACTION_TYPE_NORMAL
     };
@@ -807,8 +807,10 @@
     timeInput.onchange=()=>{
       const v=parseTimeInput(timeInput.value);
       if(v==null){
+        state.horaInicial = state.horaInicial || {};
         delete state.horaInicial.CLIENTE;
       }else{
+        state.horaInicial = state.horaInicial || {};
         state.horaInicial.CLIENTE=v;
       }
       touch();
@@ -3560,7 +3562,7 @@
 
   const projectStartCandidate = getInitialMinuteFor("CLIENTE");
   const ABSOLUTE_DAY_MIN = 0;
-  const SUGGESTED_DAY_LOWER_MIN = projectStartCandidate!=null ? normalizeMinute(projectStartCandidate) : 9*60;
+  const SUGGESTED_DAY_LOWER_MIN = projectStartCandidate!=null ? normalizeMinute(projectStartCandidate) : 0;
   const DEFAULT_DAY_LOWER_MIN = ABSOLUTE_DAY_MIN;
   const DEFAULT_DAY_UPPER_MIN = DAY_MAX_MIN;
 


### PR DESCRIPTION
## Summary
- remove the hard-coded 09:00 fallback for client timeline initialization and derived scheduling windows
- allow staff scheduling inputs to be blank so horaInicial is optional for every person
- update the bundled assets to mirror the new open-ended start behavior

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df0a1d53e8832abf5c61c0d3f56fe5